### PR TITLE
Corrrectly set macOS base version as 10.13

### DIFF
--- a/cmd/fyne/internal/commands/build.go
+++ b/cmd/fyne/internal/commands/build.go
@@ -235,8 +235,8 @@ func (b *Builder) build() error {
 	env := os.Environ()
 
 	if goos == "darwin" {
-		appendEnv(&env, "CGO_CFLAGS", "-mmacosx-version-min=10.11")
-		appendEnv(&env, "CGO_LDFLAGS", "-mmacosx-version-min=10.11")
+		appendEnv(&env, "CGO_CFLAGS", "-mmacosx-version-min=10.13")
+		appendEnv(&env, "CGO_LDFLAGS", "-mmacosx-version-min=10.13")
 	}
 
 	ldFlags := extractLdflagsFromGoFlags()


### PR DESCRIPTION
We have been telling the compiler to compile for a long since unsupported macOS version. This should hopefully make something better at least.

FYI: I haven't tested this given that I don't quite have the setup for it at the moment. I'd appreciate if you had a look while reviewing @andydotxyz.