### PR TITLE
Require that commands are passed in as static strings

### DIFF
--- a/shell.go
+++ b/shell.go
@@ -7,13 +7,15 @@ import (
 	"strings"
 )
 
-type staticString string
+// stringLiteral is a type of string that cannot be passed as a variable.
+// This helps to avoid code injection by enforcing executable names to be hard coded.
+type stringLiteral string
 
 // CommandInShell sets up a new command with the environment set up by user's environment.
 // In darwin or other Unix systems the shell will be loaded by running the terminal and accessing env command.
 // The command is run directly so stdout and stderr can be read directly from the returned `exec.Cmd`.
 // The cmd parameter must be a string constant to avoid possible code injection attacks.
-func CommandInShell(cmd staticString, args ...string) *exec.Cmd {
+func CommandInShell(cmd stringLiteral, args ...string) *exec.Cmd {
 	// lookup command path in target env
 	path := string(cmd)
 	if runtime.GOOS == "darwin" {

--- a/shell.go
+++ b/shell.go
@@ -7,14 +7,17 @@ import (
 	"strings"
 )
 
-// CommandInShell sets up a new command with the environment set up by users environment.
+type staticString string
+
+// CommandInShell sets up a new command with the environment set up by user's environment.
 // In darwin or other Unix systems the shell will be loaded by running the terminal and accessing env command.
-// The command is run directly so stdout and stderr can be read directly from the returnd `exec.Cmd`.
-func CommandInShell(cmd string, args ...string) *exec.Cmd {
+// The command is run directly so stdout and stderr can be read directly from the returned `exec.Cmd`.
+// The cmd parameter must be a string constant to avoid possible code injection attacks.
+func CommandInShell(cmd staticString, args ...string) *exec.Cmd {
 	// lookup command path in target env
-	path := cmd
+	path := string(cmd)
 	if runtime.GOOS == "darwin" {
-		data, err := runInShell("which", cmd).Output()
+		data, err := runInShell("which", path).Output()
 
 		if err == nil {
 			// parse lines as shell can output header


### PR DESCRIPTION
This is a technique I learned at GoLab and it seems like a great way to avoid command injection