### PR TITLE
Patch build.go so metadata works with "fyne package" when building app based on fyne@develop

### DIFF
--- a/cmd/fyne/internal/commands/build.go
+++ b/cmd/fyne/internal/commands/build.go
@@ -443,5 +443,9 @@ func normaliseVersion(str string) string {
 	if pos := strings.Index(str, "-0.20"); pos != -1 {
 		str = str[:pos] + "-dev"
 	}
+	
+	if pos := strings.Index(str, "-rc"); pos != -1 {
+		str = str[:pos] + "-dev"
+	}
 	return version.Normalize(str)
 }

--- a/cmd/fyne/internal/commands/build.go
+++ b/cmd/fyne/internal/commands/build.go
@@ -443,7 +443,7 @@ func normaliseVersion(str string) string {
 	if pos := strings.Index(str, "-0.20"); pos != -1 {
 		str = str[:pos] + "-dev"
 	}
-	
+
 	if pos := strings.Index(str, "-rc"); pos != -1 {
 		str = str[:pos] + "-dev"
 	}


### PR DESCRIPTION
Patch build.go so metadata works when "fyne package"ing app built on latest develop branch of fyne