### PR TITLE
Fix ldflags in GOFLAGS not being respected.

### DIFF
--- a/cmd/fyne/internal/commands/build.go
+++ b/cmd/fyne/internal/commands/build.go
@@ -196,14 +196,14 @@ func (b *Builder) build() error {
 	}
 
 	args := []string{"build"}
-	env := os.Environ()
+
+	ldFlags, env := getEnvWithLDFlagsExtracted()
 
 	if goos == "darwin" {
 		appendEnv(&env, "CGO_CFLAGS", "-mmacosx-version-min=10.13")
 		appendEnv(&env, "CGO_LDFLAGS", "-mmacosx-version-min=10.13")
 	}
 
-	ldFlags := extractLdflagsFromGoFlags()
 	if !isWeb(goos) {
 		env = append(env, "CGO_ENABLED=1") // in case someone is trying to cross-compile...
 
@@ -399,17 +399,24 @@ func appendEnv(env *[]string, varName, value string) {
 	*env = append(*env, varName+"="+value)
 }
 
-func extractLdflagsFromGoFlags() string {
-	goFlags := os.Getenv("GOFLAGS")
-
-	ldFlags, goFlags := extractLdFlags(goFlags)
-	if goFlags != "" {
-		os.Setenv("GOFLAGS", goFlags)
-	} else {
-		os.Unsetenv("GOFLAGS")
+// getEnvWithLDFlagsExtracted extracts the ldFlags from the GOFLAGS and returns the environment with those flags removed.
+func getEnvWithLDFlagsExtracted() (string, []string) {
+	env := os.Environ()
+	var initialGoFlags string
+	for i, str := range env {
+		if strings.HasPrefix(str, "GOFLAGS=") {
+			initialGoFlags = strings.TrimPrefix(str, "GOFLAGS=")
+			env = append(env[:i], env[i+1:]...)
+			break
+		}
 	}
 
-	return ldFlags
+	ldFlags, goFlags := extractLdFlags(initialGoFlags)
+	if goFlags != "" {
+		env = append(env, "GOFLAGS="+goFlags)
+	}
+
+	return ldFlags, env
 }
 
 func extractLdFlags(goFlags string) (string, string) {


### PR DESCRIPTION
`extractLdflagsFromGoFlags()` was not reentrant, but we were calling it a second time when building on windows.  PackageWindows does another build and the second one saw an environment with the ldflags stripped out.

This doesn't work before the change (version was not set) but it work after this change.

```powershell
$Env:GOFLAGS="-ldflags=-X=path/to/pkg/config.Version=v0.0.2"
fyne package -os windows -name myapp.exe -icon ./Icon.png -appBuild 1 -appVersion 1.0.0 -appID com.example.app -tags windows
```
