### PR TITLE
Print an interactive link when serving WASM

### DIFF
--- a/cmd/fyne/internal/commands/serve.go
+++ b/cmd/fyne/internal/commands/serve.go
@@ -76,7 +76,7 @@ func (s *Server) serve() error {
 
 	http.Handle("/", fileServer)
 
-	fmt.Printf("Serving %s on HTTP port: %v\n", webDir, s.port)
+	fmt.Printf("Serving %s at: http://localhost:%v\n", s.appData.AppID, s.port)
 	err = http.ListenAndServe(":"+strconv.Itoa(s.port), nil)
 
 	return err


### PR DESCRIPTION
The fact that I couldn't click on an actual link to open it in my browser drove me mad each time. Finally got around to implementing that :)