### PR TITLE
Update UNIX package installs to use AppID instead of Name

### DIFF
--- a/cmd/fyne/internal/commands/package-unix.go
+++ b/cmd/fyne/internal/commands/package-unix.go
@@ -13,13 +13,16 @@ import (
 )
 
 type unixData struct {
-	Name, Exec, Icon string
-	Local            string
-	GenericName      string
-	Categories       string
-	Comment          string
-	Keywords         string
-	ExecParams       string
+	Name        string
+	AppID       string
+	Exec        string
+	Icon        string
+	Local       string
+	GenericName string
+	Categories  string
+	Comment     string
+	Keywords    string
+	ExecParams  string
 
 	SourceRepo, SourceDir string
 }
@@ -50,15 +53,20 @@ func (p *Packager) packageUNIX() error {
 	}
 
 	iconDir := util.EnsureSubDir(shareDir, "pixmaps")
-	iconPath := filepath.Join(iconDir, p.Name+filepath.Ext(p.icon))
+	iconName := p.AppID + filepath.Ext(p.icon)
+	iconPath := filepath.Join(iconDir, iconName)
 	err = util.CopyFile(p.icon, iconPath)
 	if err != nil {
 		return fmt.Errorf("failed to copy icon: %w", err)
 	}
 
 	appsDir := util.EnsureSubDir(shareDir, "applications")
-	desktop := filepath.Join(appsDir, p.Name+".desktop")
-	deskFile, _ := os.Create(desktop)
+	desktop := filepath.Join(appsDir, p.AppID+".desktop")
+	deskFile, err := os.Create(desktop)
+	if err != nil {
+		return fmt.Errorf("failed to create desktop file: %w", err)
+	}
+
 	defer deskFile.Close()
 
 	linuxBSD := metadata.LinuxAndBSD{}
@@ -67,8 +75,9 @@ func (p *Packager) packageUNIX() error {
 	}
 	tplData := unixData{
 		Name:        p.Name,
+		AppID:       p.AppID,
 		Exec:        filepath.Base(p.exe),
-		Icon:        p.Name + filepath.Ext(p.icon),
+		Icon:        iconName,
 		Local:       local,
 		GenericName: linuxBSD.GenericName,
 		Keywords:    formatDesktopFileList(linuxBSD.Keywords),

--- a/cmd/fyne/internal/templates/data/Makefile
+++ b/cmd/fyne/internal/templates/data/Makefile
@@ -5,7 +5,7 @@ LOCAL != test -d $(DESTDIR)/usr/local && echo -n "/local" || echo -n ""
 LOCAL ?= $(shell test -d $(DESTDIR)/usr/local && echo "/local" || echo "")
 PREFIX ?= /usr$(LOCAL)
 
-Name := {{ .Name | printf "%q" }}
+AppID := {{ .AppID | printf "%q" }}
 Exec := {{ .Exec | printf "%q" }}
 Icon := {{ .Icon | printf "%q" }}
 
@@ -19,21 +19,21 @@ default:
 	# Run "sudo make uninstall" to uninstall the application.
 
 install:
-	install -Dm00644 usr/{{.Local}}share/applications/$(Name).desktop $(DESTDIR)$(PREFIX)/share/applications/$(Name).desktop
+	install -Dm00644 usr/{{.Local}}share/applications/$(AppID).desktop $(DESTDIR)$(PREFIX)/share/applications/$(AppID).desktop
 	install -Dm00755 usr/{{.Local}}bin/$(Exec) $(DESTDIR)$(PREFIX)/bin/$(Exec)
 	install -Dm00644 usr/{{.Local}}share/pixmaps/$(Icon) $(DESTDIR)$(PREFIX)/share/pixmaps/$(Icon)
 uninstall:
-	-rm $(DESTDIR)$(PREFIX)/share/applications/$(Name).desktop
+	-rm $(DESTDIR)$(PREFIX)/share/applications/$(AppID).desktop
 	-rm $(DESTDIR)$(PREFIX)/bin/$(Exec)
 	-rm $(DESTDIR)$(PREFIX)/share/pixmaps/$(Icon)
 
 user-install:
-	install -Dm00644 usr/{{.Local}}share/applications/$(Name).desktop $(DESTDIR)$(HOME)/.local/share/applications/$(Name).desktop
+	install -Dm00644 usr/{{.Local}}share/applications/$(AppID).desktop $(DESTDIR)$(HOME)/.local/share/applications/$(AppID).desktop
 	install -Dm00755 usr/{{.Local}}bin/$(Exec) $(DESTDIR)$(HOME)/.local/bin/$(Exec)
 	install -Dm00644 usr/{{.Local}}share/pixmaps/$(Icon) $(DESTDIR)$(HOME)/.local/share/icons/$(Icon)
-	sed -i -e "s,Exec=$(Exec),Exec=$(DESTDIR)$(HOME)/.local/bin/$(Exec),g" $(DESTDIR)$(HOME)/.local/share/applications/$(Name).desktop
+	sed -i -e "s,Exec=$(Exec),Exec=$(DESTDIR)$(HOME)/.local/bin/$(Exec),g" $(DESTDIR)$(HOME)/.local/share/applications/$(AppID).desktop
 
 user-uninstall:
-	-rm $(DESTDIR)$(HOME)/.local/share/applications/$(Name).desktop
+	-rm $(DESTDIR)$(HOME)/.local/share/applications/$(AppID).desktop
 	-rm $(DESTDIR)$(HOME)/.local/bin/$(Exec)
 	-rm $(DESTDIR)$(HOME)/.local/share/icons/$(Icon)

--- a/cmd/fyne/internal/templates/data/entry.desktop
+++ b/cmd/fyne/internal/templates/data/entry.desktop
@@ -4,7 +4,7 @@ Name={{.Name}}
 {{- if ne .GenericName ""}}
 GenericName={{.GenericName}}{{end}}
 Exec={{.Exec}} {{- .ExecParams}}
-Icon={{.Name}}
+Icon={{.AppID}}
 {{- if ne .Comment ""}}
 Comment={{.Comment}}{{end}}
 {{- if ne .Categories ""}}


### PR DESCRIPTION
A work in progress for using AppID over Name for icon and desktop file. This avoids problems with spaces in the name and also follows recommended praxis by most Linux distributions.