### PR TITLE
Add 'verbose' option to package command

### DIFF
--- a/cmd/fyne/internal/commands/package-mobile.go
+++ b/cmd/fyne/internal/commands/package-mobile.go
@@ -14,11 +14,11 @@ import (
 )
 
 func (p *Packager) packageAndroid(arch string, tags []string) error {
-	return mobile.RunNewBuild(arch, p.AppID, p.icon, p.Name, p.AppVersion, p.AppBuild, p.release, p.distribution, "", "", tags)
+	return mobile.RunNewBuild(arch, p.AppID, p.icon, p.Name, p.AppVersion, p.AppBuild, p.release, p.distribution, "", "", tags, p.verbose)
 }
 
 func (p *Packager) packageIOS(target string, tags []string) error {
-	err := mobile.RunNewBuild(target, p.AppID, p.icon, p.Name, p.AppVersion, p.AppBuild, p.release, p.distribution, p.certificate, p.profile, tags)
+	err := mobile.RunNewBuild(target, p.AppID, p.icon, p.Name, p.AppVersion, p.AppBuild, p.release, p.distribution, p.certificate, p.profile, tags, p.verbose)
 	if err != nil {
 		return err
 	}

--- a/cmd/fyne/internal/commands/package.go
+++ b/cmd/fyne/internal/commands/package.go
@@ -68,6 +68,7 @@ type Packager struct {
 	*appData
 	srcDir, dir, exe, os           string
 	install, release, distribution bool
+	verbose                        bool
 	certificate, profile           string // optional flags for releasing
 	tags, category                 string
 	tempDir                        string

--- a/cmd/fyne/internal/commands/release.go
+++ b/cmd/fyne/internal/commands/release.go
@@ -53,6 +53,7 @@ func Release() *cli.Command {
 			stringFlags["icon"](&r.icon),
 			boolFlags["use-raw-icon"](&r.rawIcon),
 			genericFlags["metadata"](&r.customMetadata),
+			boolFlags["verbose"](&r.Packager.verbose),
 		},
 		Action: r.releaseAction,
 	}

--- a/cmd/fyne/internal/mobile/build.go
+++ b/cmd/fyne/internal/mobile/build.go
@@ -273,11 +273,12 @@ var (
 )
 
 // RunNewBuild executes a new mobile build for the specified configuration
-func RunNewBuild(target, appID, icon, name, version string, build int, release, distribution bool, cert, profile string, tags []string) error {
+func RunNewBuild(target, appID, icon, name, version string, build int, release, distribution bool, cert, profile string, tags []string, verbose bool) error {
 	buildTarget = target
 	buildBundleID = appID
 	buildRelease = distribution
 	buildTags = tags
+	buildV = verbose
 	if release {
 		buildLdflags = "-w"
 		buildTrimpath = true

--- a/cmd/fyne/internal/mobile/build_iosapp.go
+++ b/cmd/fyne/internal/mobile/build_iosapp.go
@@ -83,11 +83,16 @@ func goIOSBuild(pkg *packages.Package, bundleID string, archs []string,
 	}
 
 	// We are using lipo tool to build multiarchitecture binaries.
-	cmd := exec.Command(
-		"xcrun", "lipo",
+	args := []string{
+		"lipo",
 		"-o", filepath.Join(tmpdir, "main/main"),
 		"-create",
-	)
+	}
+	if buildV {
+		printcmd("xcrun %s", strings.Join(args, " "))
+	}
+	cmd := exec.Command("xcrun", args...)
+
 	var nmpkgs map[string]bool
 	for _, arch := range archs {
 		path := filepath.Join(tmpdir, arch)
@@ -124,6 +129,9 @@ func goIOSBuild(pkg *packages.Package, bundleID string, archs []string,
 	}
 
 	cmd = exec.Command("xcrun", cmdStrings...)
+	if buildV {
+		printcmd("xcrun %s", strings.Join(cmdStrings, " "))
+	}
 	if err := runCmd(cmd); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is picking up from https://github.com/fyne-io/fyne/pull/3352 to fix https://github.com/fyne-io/fyne/issues/3069.

It passes the verbose value to the mobile build, and shows xcrun command invocations when enabled.

Leaves other flags as they are.