### PR TITLE
Clean up command order and usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To list all available commands enter `fyne help`:
        package, p       Packages an application for distribution
        release, r       Prepares an application for public distribution
        install, get, i  Packages and installs an application
-       serve, s         Package an application using WebAssembly and expose it via a web server
+       serve, s         Packages an application using WebAssembly and exposes it via a web server
        translate, t     Scans for new translation strings
        version, v       Shows version information for fyne
        bundle           Embeds static content into your go application

--- a/README.md
+++ b/README.md
@@ -22,15 +22,16 @@ To list all available commands enter `fyne help`:
        The fyne command provides tooling for fyne applications and to assist in their development.
     
     COMMANDS:
-       bundle           Embeds static content into your go application.
-       env, e           The env command prints the Fyne module and environment information
-       install, get, i  Packages and installs an application.
-       package, p       Packages an application for distribution.
-       release, r       Prepares an application for public distribution.
-       version, v       Shows version information for fyne.
-       serve, s         Package an application using WebAssembly and expose it via a web server.
-       translate, t     Scans for new translation strings.
-       build, b         Build an application.
+       init             Initializes a new Fyne project
+       env, e           Prints the Fyne module and environment information
+       build, b         Builds an application
+       package, p       Packages an application for distribution
+       release, r       Prepares an application for public distribution
+       install, get, i  Packages and installs an application
+       serve, s         Package an application using WebAssembly and expose it via a web server
+       translate, t     Scans for new translation strings
+       version, v       Shows version information for fyne
+       bundle           Embeds static content into your go application
        help, h          Shows a list of commands or help for one command
     
     GLOBAL OPTIONS:

--- a/cmd/fyne/internal/commands/build.go
+++ b/cmd/fyne/internal/commands/build.go
@@ -45,7 +45,7 @@ func Build() *cli.Command {
 	return &cli.Command{
 		Name:        "build",
 		Aliases:     []string{"b"},
-		Usage:       "Build an application",
+		Usage:       "Builds an application",
 		Description: "You can specify --target to define the OS to build for. The executable file will default to an appropriate name but can be overridden using -o.",
 		Flags: []cli.Flag{
 			stringFlags["target"](&b.os),

--- a/cmd/fyne/internal/commands/build.go
+++ b/cmd/fyne/internal/commands/build.go
@@ -45,7 +45,7 @@ func Build() *cli.Command {
 	return &cli.Command{
 		Name:        "build",
 		Aliases:     []string{"b"},
-		Usage:       "Build an application.",
+		Usage:       "Build an application",
 		Description: "You can specify --target to define the OS to build for. The executable file will default to an appropriate name but can be overridden using -o.",
 		Flags: []cli.Flag{
 			stringFlags["target"](&b.os),

--- a/cmd/fyne/internal/commands/bundle.go
+++ b/cmd/fyne/internal/commands/bundle.go
@@ -24,7 +24,7 @@ func Bundle() *cli.Command {
 
 	return &cli.Command{
 		Name:        "bundle",
-		Usage:       "Embeds static content into your go application.",
+		Usage:       "Embeds static content into your go application",
 		Description: "Each resource will have a generated filename unless specified.",
 		Flags: []cli.Flag{
 			&cli.StringFlag{

--- a/cmd/fyne/internal/commands/env.go
+++ b/cmd/fyne/internal/commands/env.go
@@ -18,7 +18,7 @@ func Env() *cli.Command {
 	return &cli.Command{
 		Name:    "env",
 		Aliases: []string{"e"},
-		Usage:   "The env command prints the Fyne module and environment information",
+		Usage:   "Prints the Fyne module and environment information",
 		Action: func(_ *cli.Context) error {
 			workDir, err := os.Getwd()
 			if err != nil {

--- a/cmd/fyne/internal/commands/init.go
+++ b/cmd/fyne/internal/commands/init.go
@@ -17,7 +17,7 @@ import (
 func Init() *cli.Command {
 	return &cli.Command{
 		Name:      "init",
-		Usage:     "Initializes a new Fyne project.",
+		Usage:     "Initializes a new Fyne project",
 		ArgsUsage: "[module-path]",
 		Action:    initAction,
 		Description: "Initializes a new Fyne project in the current directory, including\n" +

--- a/cmd/fyne/internal/commands/install.go
+++ b/cmd/fyne/internal/commands/install.go
@@ -26,7 +26,7 @@ func Install() *cli.Command {
 	return &cli.Command{
 		Name:      "install",
 		Aliases:   []string{"get", "i"},
-		Usage:     "Packages and installs an application.",
+		Usage:     "Packages and installs an application",
 		ArgsUsage: "[remote[@version]]",
 		Description: "The install command packages an application for the current platform and copies it\n" +
 			"into the system location for applications by default.",

--- a/cmd/fyne/internal/commands/package.go
+++ b/cmd/fyne/internal/commands/package.go
@@ -35,7 +35,7 @@ func Package() *cli.Command {
 	return &cli.Command{
 		Name:        "package",
 		Aliases:     []string{"p"},
-		Usage:       "Packages an application for distribution.",
+		Usage:       "Packages an application for distribution",
 		Description: "You may specify the -executable to package, otherwise -sourceDir will be built.",
 		Flags: []cli.Flag{
 			stringFlags["target"](&p.os),

--- a/cmd/fyne/internal/commands/release.go
+++ b/cmd/fyne/internal/commands/release.go
@@ -33,7 +33,7 @@ func Release() *cli.Command {
 	return &cli.Command{
 		Name:    "release",
 		Aliases: []string{"r"},
-		Usage:   "Prepares an application for public distribution.",
+		Usage:   "Prepares an application for public distribution",
 		Flags: []cli.Flag{
 			stringFlags["target"](&r.os),
 			stringFlags["key-store"](&r.keyStore),

--- a/cmd/fyne/internal/commands/serve.go
+++ b/cmd/fyne/internal/commands/serve.go
@@ -23,7 +23,7 @@ func Serve() *cli.Command {
 	return &cli.Command{
 		Name:        "serve",
 		Aliases:     []string{"s"},
-		Usage:       "Package an application using WebAssembly and expose it via a web server",
+		Usage:       "Packages an application using WebAssembly and exposes it via a web server",
 		Description: `The serve command packages an application using WebAssembly and expose it via a web server which port can be overridden with port.`,
 		Flags: []cli.Flag{
 			stringFlags["src"](&s.srcDir),

--- a/cmd/fyne/internal/commands/serve.go
+++ b/cmd/fyne/internal/commands/serve.go
@@ -23,7 +23,7 @@ func Serve() *cli.Command {
 	return &cli.Command{
 		Name:        "serve",
 		Aliases:     []string{"s"},
-		Usage:       "Package an application using WebAssembly and expose it via a web server.",
+		Usage:       "Package an application using WebAssembly and expose it via a web server",
 		Description: `The serve command packages an application using WebAssembly and expose it via a web server which port can be overridden with port.`,
 		Flags: []cli.Flag{
 			stringFlags["src"](&s.srcDir),

--- a/cmd/fyne/internal/commands/translate.go
+++ b/cmd/fyne/internal/commands/translate.go
@@ -26,7 +26,7 @@ func Translate() *cli.Command {
 	return &cli.Command{
 		Name:      "translate",
 		Aliases:   []string{"t"},
-		Usage:     "Scans for new translation strings.",
+		Usage:     "Scans for new translation strings",
 		ArgsUsage: "translationsFile [source ...]",
 		Description: "Recursively scans the current or given directories/files for\n" +
 			"translation strings, and creates or updates the translations file.",

--- a/cmd/fyne/internal/commands/version.go
+++ b/cmd/fyne/internal/commands/version.go
@@ -13,7 +13,7 @@ func Version() *cli.Command {
 	return &cli.Command{
 		Name:    "version",
 		Aliases: []string{"v"},
-		Usage:   "Shows version information for fyne.",
+		Usage:   "Shows version information for fyne",
 		Action: func(_ *cli.Context) error {
 			if info, ok := debug.ReadBuildInfo(); ok {
 				fmt.Println("fyne cli version:", info.Main.Version)

--- a/cmd/fyne/main.go
+++ b/cmd/fyne/main.go
@@ -15,16 +15,16 @@ func main() {
 		Usage:       "A command line helper for various Fyne tools.",
 		Description: "The fyne command provides tooling for fyne applications and to assist in their development.",
 		Commands: []*cli.Command{
-			commands.Bundle(),
+			commands.Init(),
 			commands.Env(),
-			commands.Install(),
+			commands.Build(),
 			commands.Package(),
 			commands.Release(),
-			commands.Version(),
+			commands.Install(),
 			commands.Serve(),
 			commands.Translate(),
-			commands.Build(),
-			commands.Init(),
+			commands.Version(),
+			commands.Bundle(),
 		},
 	}
 


### PR DESCRIPTION
This orders the commands by relevance (at least that's the idea), makes the command descriptions more consistent, and updates the README accordingly. No functional change.