### PR TITLE
Check the source directory for code

### DIFF
--- a/cmd/fyne/internal/commands/package.go
+++ b/cmd/fyne/internal/commands/package.go
@@ -430,12 +430,12 @@ func validateAppID(appID, os, name string, release bool) (string, error) {
 
 func hasGoCode(dir string) bool {
 	found := false
-	_ = filepath.WalkDir(dir, func(path string, de fs.DirEntry, err error) error {
-		if de.IsDir() || filepath.Ext(de.Name()) != ".go" {
+	_ = filepath.Walk(dir+string(filepath.Separator), func(path string, fi fs.FileInfo, err error) error {
+		if fi.IsDir() || filepath.Ext(path) != ".go" {
 			return err
 		}
 		found = true
-		return filepath.SkipAll
+		return err
 	})
 	return found
 }

--- a/cmd/fyne/internal/commands/package.go
+++ b/cmd/fyne/internal/commands/package.go
@@ -7,6 +7,7 @@ import (
 	"image"
 	_ "image/jpeg" // import image encodings
 	"image/png"    // import image encodings
+	"io/fs"
 	"log"
 	"os"
 	"path/filepath"
@@ -266,7 +267,12 @@ func (p *Packager) validate() (err error) {
 		}
 		p.srcDir = util.EnsureAbsPath(p.srcDir)
 	}
-	os.Chdir(p.srcDir)
+	if err := os.Chdir(p.srcDir); err != nil {
+		return err
+	}
+	if !hasGoCode(p.srcDir) {
+		return fmt.Errorf("failed to find go code in source directory: %s", p.srcDir)
+	}
 
 	p.appData.CustomMetadata = p.customMetadata.m
 	p.appData.Release = p.release
@@ -420,4 +426,16 @@ func validateAppID(appID, os, name string, release bool) (string, error) {
 	}
 
 	return appID, nil
+}
+
+func hasGoCode(dir string) bool {
+	found := false
+	_ = filepath.WalkDir(dir, func(path string, de fs.DirEntry, err error) error {
+		if de.IsDir() || filepath.Ext(de.Name()) != ".go" {
+			return err
+		}
+		found = true
+		return filepath.SkipAll
+	})
+	return found
 }

--- a/cmd/fyne/internal/commands/package.go
+++ b/cmd/fyne/internal/commands/package.go
@@ -435,7 +435,7 @@ func hasGoCode(dir string) bool {
 			return err
 		}
 		found = true
-		return err
+		return filepath.SkipAll
 	})
 	return found
 }

--- a/cmd/fyne/internal/commands/package.go
+++ b/cmd/fyne/internal/commands/package.go
@@ -428,7 +428,7 @@ func validateAppID(appID, os, name string, release bool) (string, error) {
 	return appID, nil
 }
 
-var stopWalk = errors.New("stop walking")
+var errStopWalking = errors.New("stop walking")
 
 func hasGoCode(dir string) bool {
 	found := false
@@ -437,7 +437,7 @@ func hasGoCode(dir string) bool {
 			return err
 		}
 		found = true
-		return stopWalk
+		return errStopWalking
 	})
 	return found
 }

--- a/cmd/fyne/internal/commands/package.go
+++ b/cmd/fyne/internal/commands/package.go
@@ -428,6 +428,8 @@ func validateAppID(appID, os, name string, release bool) (string, error) {
 	return appID, nil
 }
 
+var stopWalk = errors.New("stop walking")
+
 func hasGoCode(dir string) bool {
 	found := false
 	_ = filepath.Walk(dir+string(filepath.Separator), func(path string, fi fs.FileInfo, err error) error {
@@ -435,7 +437,7 @@ func hasGoCode(dir string) bool {
 			return err
 		}
 		found = true
-		return fs.SkipAll
+		return stopWalk
 	})
 	return found
 }

--- a/cmd/fyne/internal/commands/package.go
+++ b/cmd/fyne/internal/commands/package.go
@@ -435,7 +435,7 @@ func hasGoCode(dir string) bool {
 			return err
 		}
 		found = true
-		return filepath.SkipAll
+		return fs.SkipAll
 	})
 	return found
 }

--- a/cmd/fyne/internal/commands/package_test.go
+++ b/cmd/fyne/internal/commands/package_test.go
@@ -325,5 +325,12 @@ func Test_hasGoCode(t *testing.T) {
 	_, err = f.Write([]byte("package " + dir + "\n// example"))
 	assert.NoError(t, err)
 	assert.NoError(t, f.Close())
+
+	f, err = os.Create(filepath.Join(dir, "three.go"))
+	assert.NoError(t, err)
+	_, err = f.Write([]byte("package " + dir + "\n// example"))
+	assert.NoError(t, err)
+	assert.NoError(t, f.Close())
+
 	assert.True(t, hasGoCode(dir))
 }

--- a/cmd/fyne/internal/commands/package_test.go
+++ b/cmd/fyne/internal/commands/package_test.go
@@ -308,3 +308,22 @@ func Test_PowerShellArguments(t *testing.T) {
 		assert.Equal(t, test.expected, result)
 	}
 }
+
+func Test_hasGoCode(t *testing.T) {
+	dir := t.TempDir()
+	assert.False(t, hasGoCode(dir))
+
+	f, err := os.Create(filepath.Join(dir, "one.txt"))
+	assert.NoError(t, err)
+	_, err = f.Write([]byte("something\n"))
+	assert.NoError(t, err)
+	assert.NoError(t, f.Close())
+	assert.False(t, hasGoCode(dir))
+
+	f, err = os.Create(filepath.Join(dir, "two.go"))
+	assert.NoError(t, err)
+	_, err = f.Write([]byte("package " + dir + "\n// example"))
+	assert.NoError(t, err)
+	assert.NoError(t, f.Close())
+	assert.True(t, hasGoCode(dir))
+}


### PR DESCRIPTION
This addresses the confusing output mentioned in: https://github.com/fyne-io/tools/issues/44

Making sure the source directory contains code seems like an easy way to prevent this from being confusing.