### PR TITLE
Stop indenting FyneApp.toml

### DIFF
--- a/cmd/fyne/internal/metadata/save.go
+++ b/cmd/fyne/internal/metadata/save.go
@@ -1,7 +1,7 @@
 package metadata
 
 import (
-	"bytes"
+	"bufio"
 	"io"
 	"os"
 	"path/filepath"
@@ -12,14 +12,12 @@ import (
 // Save attempts to write a FyneApp metadata to the provided writer.
 // If the encoding fails an error will be returned.
 func Save(f *FyneApp, w io.Writer) error {
-	var buf bytes.Buffer
-	err := toml.NewEncoder(&buf).Encode(f)
-	if err != nil {
-		return err
-	}
+	bw := bufio.NewWriter(w)
+	defer bw.Flush()
 
-	_, err = w.Write(buf.Bytes())
-	return err
+	enc := toml.NewEncoder(bw)
+	enc.Indent = ""
+	return enc.Encode(f)
 }
 
 // SaveStandard attempts to save a FyneApp metadata to the `FyneApp.toml` file in the specified dir.

--- a/cmd/fyne/internal/metadata/save_test.go
+++ b/cmd/fyne/internal/metadata/save_test.go
@@ -35,3 +35,24 @@ func TestSaveAppMetadata(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 2, data2.Details.Build)
 }
+
+func TestSaveIndentation(t *testing.T) {
+	r, err := os.Open("./testdata/FyneApp.toml")
+	assert.Nil(t, err)
+	data, err := Load(r)
+	assert.Nil(t, err)
+	r.Close()
+
+	w, err := os.Create("./testdata/new.toml")
+	assert.Nil(t, err)
+	t.Cleanup(func() { os.Remove("./testdata/new.toml") })
+	err = Save(data, w)
+	assert.Nil(t, err)
+	w.Close()
+
+	expected, err := os.ReadFile("./testdata/FyneApp.toml")
+	assert.Nil(t, err)
+	actual, err := os.ReadFile("./testdata/new.toml")
+	assert.Nil(t, err)
+	assert.Equal(t, expected, actual)
+}

--- a/cmd/fyne/internal/metadata/save_test.go
+++ b/cmd/fyne/internal/metadata/save_test.go
@@ -2,7 +2,7 @@ package metadata
 
 import (
 	"os"
-	"strings"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -38,6 +38,10 @@ func TestSaveAppMetadata(t *testing.T) {
 }
 
 func TestSaveIndentation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Don't run indentation tests on Windows, seems to fail for no apparent reason")
+	}
+
 	r, err := os.Open("./testdata/FyneApp.toml")
 	assert.Nil(t, err)
 	data, err := Load(r)
@@ -53,8 +57,7 @@ func TestSaveIndentation(t *testing.T) {
 
 	expected, err := os.ReadFile("./testdata/FyneApp.toml")
 	assert.Nil(t, err)
-	got, err := os.ReadFile("./testdata/new.toml")
+	actual, err := os.ReadFile("./testdata/new.toml")
 	assert.Nil(t, err)
-	actual := strings.ReplaceAll(string(got), "\r\n", "\n")
 	assert.Equal(t, string(expected), string(actual))
 }

--- a/cmd/fyne/internal/metadata/save_test.go
+++ b/cmd/fyne/internal/metadata/save_test.go
@@ -1,8 +1,10 @@
 package metadata
 
 import (
+	"bytes"
 	"os"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -48,16 +50,13 @@ func TestSaveIndentation(t *testing.T) {
 	assert.Nil(t, err)
 	r.Close()
 
-	w, err := os.Create("./testdata/new.toml")
-	assert.Nil(t, err)
-	t.Cleanup(func() { os.Remove("./testdata/new.toml") })
+	w := &bytes.Buffer{}
 	err = Save(data, w)
 	assert.Nil(t, err)
-	w.Close()
 
-	expected, err := os.ReadFile("./testdata/FyneApp.toml")
+	content, err := os.ReadFile("./testdata/FyneApp.toml")
 	assert.Nil(t, err)
-	actual, err := os.ReadFile("./testdata/new.toml")
-	assert.Nil(t, err)
-	assert.Equal(t, string(expected), string(actual))
+	expected := strings.ReplaceAll(string(content), "\r\n", "\n")
+	actual := strings.ReplaceAll(w.String(), "\r\n", "\n")
+	assert.Equal(t, expected, actual)
 }

--- a/cmd/fyne/internal/metadata/save_test.go
+++ b/cmd/fyne/internal/metadata/save_test.go
@@ -54,5 +54,5 @@ func TestSaveIndentation(t *testing.T) {
 	assert.Nil(t, err)
 	actual, err := os.ReadFile("./testdata/new.toml")
 	assert.Nil(t, err)
-	assert.Equal(t, expected, actual)
+	assert.Equal(t, string(expected), string(actual))
 }

--- a/cmd/fyne/internal/metadata/save_test.go
+++ b/cmd/fyne/internal/metadata/save_test.go
@@ -3,7 +3,6 @@ package metadata
 import (
 	"bytes"
 	"os"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -40,10 +39,6 @@ func TestSaveAppMetadata(t *testing.T) {
 }
 
 func TestSaveIndentation(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Don't run indentation tests on Windows, seems to fail for no apparent reason")
-	}
-
 	r, err := os.Open("./testdata/FyneApp.toml")
 	assert.Nil(t, err)
 	data, err := Load(r)

--- a/cmd/fyne/internal/metadata/save_test.go
+++ b/cmd/fyne/internal/metadata/save_test.go
@@ -2,6 +2,7 @@ package metadata
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -52,7 +53,8 @@ func TestSaveIndentation(t *testing.T) {
 
 	expected, err := os.ReadFile("./testdata/FyneApp.toml")
 	assert.Nil(t, err)
-	actual, err := os.ReadFile("./testdata/new.toml")
+	got, err := os.ReadFile("./testdata/new.toml")
 	assert.Nil(t, err)
+	actual := strings.ReplaceAll(string(got), "\r\n", "\n")
 	assert.Equal(t, string(expected), string(actual))
 }

--- a/cmd/fyne/internal/metadata/testdata/FyneApp.toml
+++ b/cmd/fyne/internal/metadata/testdata/FyneApp.toml
@@ -1,20 +1,20 @@
 Website = "https://apps.fyne.io"
 
 [Details]
+Icon = "https://conf.fyne.io/assets/img/fyne.png"
 Name = "Fyne App"
 ID = "io.fyne.fyne"
-Icon = "https://conf.fyne.io/assets/img/fyne.png"
 Version = "1.0.0"
 Build = 1
+
+[Development]
+InDevelopmentOnly = "Value4"
+Test = "Value2"
+
+[Release]
+InReleaseOnly = "Value3"
+Test = "Value1"
 
 [Source]
 Repo = "https://github.com/fyne-io/fyne"
 Dir = "internal/metadata/testdata"
-
-[Release]
-Test = "Value1"
-InReleaseOnly = "Value3"
-
-[Development]
-Test = "Value2"
-InDevelopmentOnly = "Value4"

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	fyne.io/fyne/v2 v2.6.0
-	github.com/BurntSushi/toml v1.4.0
+	github.com/BurntSushi/toml v1.5.0
 	github.com/fogleman/gg v1.3.0
 	github.com/fyne-io/image v0.1.1
 	github.com/go-ole/go-ole v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 fyne.io/fyne/v2 v2.6.0 h1:Rywo9yKYN4qvNuvkRuLF+zxhJYWbIFM+m4N4KV4p1pQ=
 fyne.io/fyne/v2 v2.6.0/go.mod h1:YZt7SksjvrSNJCwbWFV32WON3mE1Sr7L41D29qMZ/lU=
-github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0=
-github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg=
+github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/akavel/rsrc v0.10.2 h1:Zxm8V5eI1hW4gGaYsJQUhxpjkENuG91ki8B4zCrvEsw=
 github.com/akavel/rsrc v0.10.2/go.mod h1:uLoCtb9J+EyAqh+26kdrTgmzRBFPGOolLWKpdxkKq+c=
 github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=


### PR DESCRIPTION
The standard for TOML files seem to be to not indent parts of the file. Looking at https://toml.io/en/, their examples do not indent and neither do Rust's cargo.toml file. I am doing this change mostly because the automatic formatting of TOML files in Zed also removes the indentation just to have it added back again by Fyne.