### PR TITLE
Update CI to match Fyne and also run gofumpt

### DIFF
--- a/.github/workflows/fyne-qa-all.yml
+++ b/.github/workflows/fyne-qa-all.yml
@@ -4,9 +4,9 @@ on:
   workflow_call:
     inputs:
       tags:
-        description: 'Tags to pass when running tests'
+        description: "Tags to pass when running tests"
         required: false
-        default: ''
+        default: ""
         type: string
 
 jobs:
@@ -21,9 +21,9 @@ jobs:
     with:
       branch: master
       tags: ${{ inputs.tags }}
-        
-  qa-v2_4:
+
+  qa-v2_6:
     uses: fyne-io/tools/.github/workflows/fyne-qa.yml@main
     with:
-      branch: "release/v2.4.x"
+      branch: "release/v2.6.x"
       tags: ${{ inputs.tags }}

--- a/.github/workflows/platform_tests.yml
+++ b/.github/workflows/platform_tests.yml
@@ -9,16 +9,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ['1.19.x', 'stable']
+        go-version: ["", "stable"]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
-    - uses: actions/checkout@v4
-      with:
-        persist-credentials: false
-    - uses: WillAbides/setup-go-faster@v1
-      with:
-        go-version: ${{ matrix.go-version }}
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+          go-version-file: "go.mod"
 
-    - name: Tests
-      run: go test "-test.benchtime" 10ms -tags ci ./...
+      - name: Tests
+        run: go test -race -tags ci ./...

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -6,32 +6,37 @@ permissions:
 jobs:
   static_analysis:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
 
     steps:
-    - uses: actions/checkout@v4
-      with:
-        persist-credentials: false
-    - uses: WillAbides/setup-go-faster@v1
-      with:
-        go-version: 'stable'
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "stable"
 
-    - name: Install analysis tools
-      run: |
-        go install golang.org/x/tools/cmd/goimports@latest
-        go install github.com/fzipp/gocyclo/cmd/gocyclo@latest
-        go install honnef.co/go/tools/cmd/staticcheck@latest
-        go install github.com/mattn/goveralls@latest
+      - name: Install analysis tools
+        run: |
+          go install mvdan.cc/gofumpt@latest
+          go install golang.org/x/tools/cmd/goimports@latest
+          go install github.com/fzipp/gocyclo/cmd/gocyclo@latest
+          go install honnef.co/go/tools/cmd/staticcheck@latest
+          go install github.com/mattn/goveralls@latest
+          go install lucor.dev/lian@latest
 
-    - name: Vet
-      run: go vet ./...
+      - name: Vet
+        run: go vet ./...
 
-    - name: Goimports
-      run: test -z "$(goimports -e -d . | tee /dev/stderr)"
+      - name: Formatting
+        run: |
+          gofumpt -d -e .
+          test -z "$(goimports -e -d . | tee /dev/stderr)"
 
-    - name: Gocyclo
-      run: gocyclo -over 30 .
+      - name: Gocyclo
+        run: gocyclo -over 30 .
 
-    - name: Staticcheck
-      run: staticcheck ./...
+      - name: Staticcheck
+        run: staticcheck ./...
+
+      - name: Check license of dependencies
+        run: lian -d --allowed="Apache-2.0, BSD-2-Clause, BSD-3-Clause, MIT, ISC"

--- a/cmd/fyne/internal/commands/build.go
+++ b/cmd/fyne/internal/commands/build.go
@@ -329,7 +329,8 @@ func createMetadataInitFile(srcdir string, app *appData) (func(), error) {
 }
 
 func injectMetadataIfPossible(runner runner, srcdir string, app *appData,
-	createMetadataInitFile func(srcdir string, app *appData) (func(), error)) (func(), error) {
+	createMetadataInitFile func(srcdir string, app *appData) (func(), error),
+) (func(), error) {
 	fyneGoModVersion, err := getFyneGoModVersion(runner)
 	if err != nil {
 		return nil, err

--- a/cmd/fyne/internal/commands/bundle.go
+++ b/cmd/fyne/internal/commands/bundle.go
@@ -110,7 +110,7 @@ func (b *Bundler) Run(args []string) {
 			fileModes = os.O_RDWR | os.O_APPEND
 		}
 
-		f, err := os.OpenFile(b.out, fileModes, 0666)
+		f, err := os.OpenFile(b.out, fileModes, 0o666)
 		if err == nil {
 			outFile = f
 		} else {
@@ -224,7 +224,7 @@ func openOutputFile(filePath string, noheader bool) (file *os.File, close func()
 		fileModes = os.O_RDWR | os.O_APPEND
 	}
 
-	f, err := os.OpenFile(filePath, fileModes, 0666)
+	f, err := os.OpenFile(filePath, fileModes, 0o666)
 	if err != nil {
 		if !os.IsNotExist(err) {
 			fyne.LogError("Unable to open output file", err)

--- a/cmd/fyne/internal/commands/package-darwin.go
+++ b/cmd/fyne/internal/commands/package-darwin.go
@@ -48,8 +48,10 @@ func (p *Packager) packageDarwin() (err error) {
 		}
 	}()
 
-	tplData := darwinData{Name: p.Name, ExeName: exeName, AppID: p.AppID, Version: p.AppVersion, Build: p.AppBuild,
-		Category: strings.ToLower(p.category), Languages: darwinLangs(p.langs)}
+	tplData := darwinData{
+		Name: p.Name, ExeName: exeName, AppID: p.AppID, Version: p.AppVersion, Build: p.AppBuild,
+		Category: strings.ToLower(p.category), Languages: darwinLangs(p.langs),
+	}
 	if err := templates.InfoPlistDarwin.Execute(infoFile, tplData); err != nil {
 		return fmt.Errorf("failed to write plist template: %w", err)
 	}

--- a/cmd/fyne/internal/commands/package-mobile.go
+++ b/cmd/fyne/internal/commands/package-mobile.go
@@ -30,7 +30,7 @@ func (p *Packager) packageIOS(target string, tags []string) error {
     "author" : "xcode",
     "version" : 1
   }
-}`), 0644)
+}`), 0o644)
 	if err != nil {
 		fyne.LogError("Content err", err)
 	}

--- a/cmd/fyne/internal/commands/package-util-mock_test.go
+++ b/cmd/fyne/internal/commands/package-util-mock_test.go
@@ -7,20 +7,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var utilExistsMock func(path string) bool
-var utilCopyFileMock func(source string, target string) error
-var utilCopyExeFileMock func(src, tgt string) error
-var utilWriteFileMock func(target string, data []byte) error
-var utilEnsureSubDirMock func(parent, name string) string
-var utilEnsureAbsPathMock func(path string) string
-var utilMakePathRelativeToMock func(root, path string) string
+var (
+	utilExistsMock             func(path string) bool
+	utilCopyFileMock           func(source string, target string) error
+	utilCopyExeFileMock        func(src, tgt string) error
+	utilWriteFileMock          func(target string, data []byte) error
+	utilEnsureSubDirMock       func(parent, name string) string
+	utilEnsureAbsPathMock      func(path string) string
+	utilMakePathRelativeToMock func(root, path string) string
+)
 
-var utilRequireAndroidSDKMock func() error
-var utilAndroidBuildToolsPathMock func() string
+var (
+	utilRequireAndroidSDKMock     func() error
+	utilAndroidBuildToolsPathMock func() string
+)
 
-var utilIsAndroidMock func(os string) bool
-var utilIsIOSMock func(os string) bool
-var utilIsMobileMock func(os string) bool
+var (
+	utilIsAndroidMock func(os string) bool
+	utilIsIOSMock     func(os string) bool
+	utilIsMobileMock  func(os string) bool
+)
 
 type mockUtil struct{}
 
@@ -77,7 +83,6 @@ func (m *mockCopyFileRuns) verifyExpectation(t *testing.T, executable bool, sour
 	assert.Equal(t, m.expected[m.current].executable, executable)
 
 	return m.expected[m.current].ret
-
 }
 
 func (m mockUtil) CopyFile(source string, target string) error {

--- a/cmd/fyne/internal/commands/package-util.go
+++ b/cmd/fyne/internal/commands/package-util.go
@@ -38,7 +38,7 @@ func (d defaultUtil) CopyExeFile(src, tgt string) error {
 }
 
 func (d defaultUtil) WriteFile(target string, data []byte) error {
-	return os.WriteFile(target, data, 0644)
+	return os.WriteFile(target, data, 0o644)
 }
 
 func (d defaultUtil) EnsureSubDir(parent, name string) string {

--- a/cmd/fyne/internal/commands/release.go
+++ b/cmd/fyne/internal/commands/release.go
@@ -211,7 +211,7 @@ func (r *Releaser) packageIOSRelease() error {
 	}
 
 	payload := filepath.Join(r.dir, "Payload")
-	_ = os.Mkdir(payload, 0750)
+	_ = os.Mkdir(payload, 0o750)
 	defer os.RemoveAll(payload)
 	appName := mobile.AppOutputName(r.os, r.Name, r.release)
 	payloadAppDir := filepath.Join(payload, appName)
@@ -274,7 +274,7 @@ func (r *Releaser) packageMacOSRelease() error {
 
 func (r *Releaser) packageWindowsRelease(outFile string) error {
 	payload := filepath.Join(r.dir, "Payload")
-	_ = os.Mkdir(payload, 0750)
+	_ = os.Mkdir(payload, 0o750)
 	defer os.RemoveAll(payload)
 
 	manifestPath := filepath.Join(payload, "appxmanifest.xml")

--- a/cmd/fyne/internal/mobile/binres/genarsc.go
+++ b/cmd/fyne/internal/mobile/binres/genarsc.go
@@ -37,7 +37,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	if err := os.WriteFile("arsc.go", []byte(fmt.Sprintf(tmpl, strconv.Quote(string(arsc)))), 0644); err != nil {
+	if err := os.WriteFile("arsc.go", []byte(fmt.Sprintf(tmpl, strconv.Quote(string(arsc)))), 0o644); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/cmd/fyne/internal/mobile/binres/table.go
+++ b/cmd/fyne/internal/mobile/binres/table.go
@@ -74,10 +74,10 @@ func NewMipmapTable(pkgname string) (*Table, string) {
 
 	pkg.specs = append(pkg.specs,
 		&TypeSpec{
-			id: uint8(attr) + 1, //1,
+			id: uint8(attr) + 1, // 1,
 		},
 		&TypeSpec{
-			id:         uint8(mipmap) + 1, //2,
+			id:         uint8(mipmap) + 1, // 2,
 			entryCount: 1,
 			entries:    []uint32{uint32(icon)}, // {0}
 			types:      []*Type{typ},

--- a/cmd/fyne/internal/mobile/build_androidapp.go
+++ b/cmd/fyne/internal/mobile/build_androidapp.go
@@ -36,7 +36,8 @@ type manifestTmplData struct {
 }
 
 func goAndroidBuild(pkg *packages.Package, bundleID string, androidArchs []string,
-	iconPath, appName, version string, build, target int, release bool) (map[string]bool, error) {
+	iconPath, appName, version string, build, target int, release bool,
+) (map[string]bool, error) {
 	ndkRoot, err := ndkRoot()
 	if err != nil {
 		return nil, err
@@ -381,7 +382,7 @@ func convertAPKToAAB(aabPath string) error {
 	apkPath := buildO[:len(aabPath)-3] + "apk"
 	apkProtoPath := buildO[:len(aabPath)-3] + "apk-proto"
 	tmpPath := filepath.Join(filepath.Dir(aabPath), "tmpbundle")
-	err := os.MkdirAll(tmpPath, 0755)
+	err := os.MkdirAll(tmpPath, 0o755)
 	if err != nil {
 		return err
 	}
@@ -406,8 +407,8 @@ func convertAPKToAAB(aabPath string) error {
 	}
 	_ = os.Remove(apkProtoPath)
 
-	_ = os.MkdirAll(filepath.Join(tmpPath, "dex"), 0755)
-	_ = os.MkdirAll(filepath.Join(tmpPath, "manifest"), 0755)
+	_ = os.MkdirAll(filepath.Join(tmpPath, "dex"), 0o755)
+	_ = os.MkdirAll(filepath.Join(tmpPath, "manifest"), 0o755)
 	_ = os.Rename(filepath.Join(tmpPath, "AndroidManifest.xml"), filepath.Join(tmpPath, "manifest", "AndroidManifest.xml"))
 	_ = os.Rename(filepath.Join(tmpPath, "classes.dex"), filepath.Join(tmpPath, "dex", "classes.dex"))
 

--- a/cmd/fyne/internal/mobile/build_iosapp.go
+++ b/cmd/fyne/internal/mobile/build_iosapp.go
@@ -21,7 +21,8 @@ import (
 )
 
 func goIOSBuild(pkg *packages.Package, bundleID string, archs []string,
-	appName, version string, build int, release bool, cert, profile string) (map[string]bool, error) {
+	appName, version string, build int, release bool, cert, profile string,
+) (map[string]bool, error) {
 	src := pkg.PkgPath
 	buildO = rfc1034Label(appName) + ".app"
 	// Detect the team ID
@@ -76,7 +77,7 @@ func goIOSBuild(pkg *packages.Package, bundleID string, archs []string,
 			printcmd("echo \"%s\" > %s", file.contents, file.name)
 		}
 		if !buildN {
-			if err := os.WriteFile(file.name, file.contents, 0600); err != nil {
+			if err := os.WriteFile(file.name, file.contents, 0o600); err != nil {
 				return nil, err
 			}
 		}

--- a/cmd/fyne/internal/mobile/env.go
+++ b/cmd/fyne/internal/mobile/env.go
@@ -303,7 +303,7 @@ func environ(kv []string) []string {
 			new = append(new, ev)
 			continue
 		}
-		if goos == "windows" {
+		if runtime.GOOS == "windows" {
 			elem[0] = strings.ToUpper(elem[0])
 		}
 		envs[elem[0]] = elem[1]
@@ -313,7 +313,7 @@ func environ(kv []string) []string {
 		if len(elem) != 2 || elem[0] == "" {
 			panic(fmt.Sprintf("malformed env var %q from input", ev))
 		}
-		if goos == "windows" {
+		if runtime.GOOS == "windows" {
 			elem[0] = strings.ToUpper(elem[0])
 		}
 		envs[elem[0]] = elem[1]

--- a/cmd/fyne/internal/mobile/gendex/gendex.go
+++ b/cmd/fyne/internal/mobile/gendex/gendex.go
@@ -55,7 +55,7 @@ func gendex() error {
 	if androidHome == "" {
 		return errors.New("ANDROID_HOME not set")
 	}
-	if err := os.MkdirAll(tmpdir+"/work/org/golang/app", 0775); err != nil {
+	if err := os.MkdirAll(tmpdir+"/work/org/golang/app", 0o775); err != nil {
 		return err
 	}
 	javaFiles, err := filepath.Glob("../../../../../../fyne/internal/driver/mobile/app/*.java")

--- a/cmd/fyne/internal/mobile/init.go
+++ b/cmd/fyne/internal/mobile/init.go
@@ -14,8 +14,6 @@ import (
 	"strings"
 )
 
-var goos = runtime.GOOS
-
 func mkdir(dir string) error {
 	if buildX || buildN {
 		printcmd("mkdir -p %s", dir)
@@ -32,15 +30,6 @@ func removeAll(path string) error {
 	}
 	if buildN {
 		return nil
-	}
-
-	// os.RemoveAll behaves differently in windows.
-	// http://golang.org/issues/9606
-	if goos == "windows" {
-		err := resetReadOnlyFlagAll(path)
-		if err != nil {
-			return err
-		}
 	}
 
 	return os.RemoveAll(path)
@@ -105,7 +94,7 @@ func runCmd(cmd *exec.Cmd) error {
 	}
 
 	if buildWork {
-		if goos == "windows" {
+		if runtime.GOOS == "windows" {
 			cmd.Env = append(cmd.Env, `TEMP=`+tmpdir, `TMP=`+tmpdir)
 		} else {
 			cmd.Env = append(cmd.Env, `TMPDIR=`+tmpdir)

--- a/cmd/fyne/internal/mobile/init.go
+++ b/cmd/fyne/internal/mobile/init.go
@@ -14,9 +14,7 @@ import (
 	"strings"
 )
 
-var (
-	goos = runtime.GOOS
-)
+var goos = runtime.GOOS
 
 func mkdir(dir string) error {
 	if buildX || buildN {
@@ -25,7 +23,7 @@ func mkdir(dir string) error {
 	if buildN {
 		return nil
 	}
-	return os.MkdirAll(dir, 0750)
+	return os.MkdirAll(dir, 0o750)
 }
 
 func removeAll(path string) error {
@@ -54,7 +52,7 @@ func resetReadOnlyFlagAll(path string) error {
 		return err
 	}
 	if !fi.IsDir() {
-		return os.Chmod(path, 0600)
+		return os.Chmod(path, 0o600)
 	}
 	fd, err := os.Open(filepath.Clean(path))
 	if err != nil {

--- a/cmd/fyne/internal/mobile/init.go
+++ b/cmd/fyne/internal/mobile/init.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"runtime"
 	"strings"
 )

--- a/cmd/fyne/internal/mobile/init.go
+++ b/cmd/fyne/internal/mobile/init.go
@@ -35,30 +35,6 @@ func removeAll(path string) error {
 	return os.RemoveAll(path)
 }
 
-func resetReadOnlyFlagAll(path string) error {
-	fi, err := os.Stat(path)
-	if err != nil {
-		return err
-	}
-	if !fi.IsDir() {
-		return os.Chmod(path, 0o600)
-	}
-	fd, err := os.Open(filepath.Clean(path))
-	if err != nil {
-		return err
-	}
-	defer fd.Close()
-
-	names, _ := fd.Readdirnames(-1)
-	for _, name := range names {
-		err := resetReadOnlyFlagAll(path + string(filepath.Separator) + name)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 func goEnv(name string) string {
 	if val := os.Getenv(name); val != "" {
 		return val

--- a/cmd/fyne/internal/mobile/main.go
+++ b/cmd/fyne/internal/mobile/main.go
@@ -10,9 +10,7 @@ import (
 	"os"
 )
 
-var (
-	gomobileName = "gomobile"
-)
+var gomobileName = "gomobile"
 
 type command struct {
 	run   func(*command) error

--- a/cmd/fyne/internal/mobile/main.go
+++ b/cmd/fyne/internal/mobile/main.go
@@ -10,7 +10,7 @@ import (
 	"os"
 )
 
-var gomobileName = "gomobile"
+const gomobileName = "gomobile"
 
 type command struct {
 	run   func(*command) error

--- a/cmd/fyne/internal/util/file.go
+++ b/cmd/fyne/internal/util/file.go
@@ -19,12 +19,12 @@ func Exists(path string) bool {
 
 // CopyFile copies the content of a regular file, source, into target path.
 func CopyFile(source, target string) error {
-	return copyFileMode(source, target, 0644)
+	return copyFileMode(source, target, 0o644)
 }
 
 // CopyExeFile copies the content of an executable file, source, into target path.
 func CopyExeFile(src, tgt string) error {
-	return copyFileMode(src, tgt, 0755)
+	return copyFileMode(src, tgt, 0o755)
 }
 
 // EnsureSubDir will make sure a named directory exists within the parent - creating it if not.


### PR DESCRIPTION
Makes sure that we run all static analysis tests as in regular Fyne plus use gofumpt like in https://github.com/fyne-io/fyne/pull/5787.