### PR TITLE
Use embed instead of including bytes

### DIFF
--- a/cmd/fyne/internal/commands/bundle.go
+++ b/cmd/fyne/internal/commands/bundle.go
@@ -253,18 +253,20 @@ func writeHeader(pkg string, out *os.File) {
 	out.WriteString(fileHeader)
 	out.WriteString("\n\npackage ")
 	out.WriteString(pkg)
-	out.WriteString("\n\nimport \"fyne.io/fyne/v2\"\n\n")
+	out.WriteString("\n\nimport (\n")
+	out.WriteString("\t_ \"embed\"\n")
+	out.WriteString("\t\"fyne.io/fyne/v2\"\n")
+	out.WriteString(")\n\n")
 }
 
 func writeResource(file, name string, f *os.File) {
-	res, err := fyne.LoadResourceFromPath(file)
+	_, err := fmt.Fprintf(f, "//go:embed %s\nvar %sData []byte\n", file, name)
 	if err != nil {
-		fyne.LogError("Unable to load file "+file, err)
-		return
+		fyne.LogError("Unable to write to bundled file", err)
 	}
 
-	const format = "var %s = &fyne.StaticResource{\n\tStaticName: %q,\n\tStaticContent: []byte(\n\t\t%q),\n}\n"
-	_, err = fmt.Fprintf(f, format, name, res.Name(), res.Content())
+	const format = "var %s = &fyne.StaticResource{\n\tStaticName: %q,\n\tStaticContent: %sData,\n}\n"
+	_, err = fmt.Fprintf(f, format, name, file, name)
 	if err != nil {
 		fyne.LogError("Unable to write to bundled file", err)
 	}

--- a/cmd/fyne/internal/commands/bundle.go
+++ b/cmd/fyne/internal/commands/bundle.go
@@ -212,10 +212,11 @@ func (b *Bundler) doBundle(filepath string, out *os.File) {
 		writeHeader(b.pkg, out)
 	}
 
-	if b.name == "" {
-		b.name = sanitiseName(path.Base(filepath), b.prefix)
+	name := b.name
+	if name == "" {
+		name = sanitiseName(path.Base(filepath), b.prefix)
 	}
-	writeResource(filepath, b.name, out)
+	writeResource(filepath, name, out)
 }
 
 func openOutputFile(filePath string, noheader bool) (file *os.File, close func() error, err error) {

--- a/cmd/fyne/internal/commands/bundle_test.go
+++ b/cmd/fyne/internal/commands/bundle_test.go
@@ -42,8 +42,8 @@ func TestWriteResource(t *testing.T) {
 	writeHeader("test", f)
 	writeResource("testdata/bundle/content.txt", "contentTxt", f)
 
-	const header = fileHeader + "\n\npackage test\n\nimport \"fyne.io/fyne/v2\"\n\n"
-	const expected = header + "var contentTxt = &fyne.StaticResource{\n\tStaticName: \"content.txt\",\n\tStaticContent: []byte(\n\t\t\"I am bundled :)\"),\n}\n"
+	const header = fileHeader + "\n\npackage test\n\nimport (\n\t_ \"embed\"\n\t\"fyne.io/fyne/v2\"\n)\n\n"
+	const expected = header + "//go:embed testdata/bundle/content.txt\nvar contentTxtData []byte\nvar contentTxt = &fyne.StaticResource{\n\tStaticName: \"testdata/bundle/content.txt\",\n\tStaticContent: contentTxtData,\n}\n"
 
 	// Seek file to start so we can read the written data.
 	_, err = f.Seek(0, io.SeekStart)


### PR DESCRIPTION
The title says it all, but it changes behavior and implies that resource files are kept around.