### PR TITLE
Make sure translation files end with a newline

### DIFF
--- a/cmd/fyne/internal/commands/translate.go
+++ b/cmd/fyne/internal/commands/translate.go
@@ -185,6 +185,10 @@ func writeTranslationsFile(b []byte, file string) error {
 		return err
 	}
 
+	if len(b) > 0 && b[len(b)-1] != '\n' {
+		b = append(b, '\n')
+	}
+
 	n, err := nf.Write(b)
 	if err != nil {
 		return err

--- a/cmd/fyne/internal/commands/translate_test.go
+++ b/cmd/fyne/internal/commands/translate_test.go
@@ -6,7 +6,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -140,7 +140,7 @@ func TestWriteTranslationsFile(t *testing.T) {
 	f, err := os.Open(dst)
 	if assert.NoError(t, err) {
 		defer f.Close()
-		b, err := ioutil.ReadAll(f)
+		b, err := io.ReadAll(f)
 		assert.NoError(t, err)
 		if assert.GreaterOrEqual(t, len(b), 1) {
 			assert.Equal(t, byte('\n'), b[len(b)-1])

--- a/cmd/fyne/internal/commands/translate_test.go
+++ b/cmd/fyne/internal/commands/translate_test.go
@@ -6,9 +6,12 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const exampleSource = `
@@ -132,6 +135,16 @@ func TestWriteTranslationsFile(t *testing.T) {
 
 	if err := writeTranslationsFile([]byte(`{"a":2}`), dst); err != nil {
 		t.Fatalf("failed to write translations file: %v", err)
+	}
+
+	f, err := os.Open(dst)
+	if assert.NoError(t, err) {
+		defer f.Close()
+		b, err := ioutil.ReadAll(f)
+		assert.NoError(t, err)
+		if assert.GreaterOrEqual(t, len(b), 1) {
+			assert.Equal(t, byte('\n'), b[len(b)-1])
+		}
 	}
 }
 


### PR DESCRIPTION
This prevents hints, messages, and/or warnings from git and other tools that want files to end on a newline, and makes it easier to work on the command line without causing constant newline add/removal jitter.