### PR TITLE
Make library version output deterministic and more forgiving

### DIFF
--- a/cmd/fyne/internal/commands/version.go
+++ b/cmd/fyne/internal/commands/version.go
@@ -28,16 +28,20 @@ func Version() *cli.Command {
 				return err
 			}
 
-			wdInfo := &report.GoMod{WorkDir: wd, Module: fyneModule}
-			info2, err := wdInfo.Info()
-			if err != nil {
-				return err
+			ver := "(not found)"
+			if wd, err := lookupDirWithGoMod(wd); err == nil {
+				wdInfo := &report.GoMod{WorkDir: wd, Module: fyneModule}
+				info2, err := wdInfo.Info()
+				if err != nil {
+					return err
+				}
+
+				if imported, ok := info2["imported"]; ok && imported.(bool) {
+					ver = info2["version"].(string)
+				}
 			}
 
-			if imported, ok := info2["imported"]; ok && imported.(bool) {
-				fmt.Println("fyne library version:", info2["version"])
-			}
-
+			fmt.Println("fyne library version:", ver)
 			return nil
 		},
 	}


### PR DESCRIPTION
Make library version output deterministic and provide better output when no library can be found instead of throwing an error.

## Before
```
$ fyne version; echo $?
fyne cli version: (devel)
go.mod not found in ~/go/src/fyne.io/fyne/v2
1
```

## After
```
$ fyne version; echo $?
fyne cli version: (devel)
fyne library version: (not found)
0
```