### PR TITLE
Refine whitespace for bundle command to match gofumpt

### DIFF
--- a/cmd/fyne/internal/commands/bundle.go
+++ b/cmd/fyne/internal/commands/bundle.go
@@ -266,16 +266,16 @@ func writeHeader(pkg string, out *os.File) {
 	out.WriteString("\n\nimport (\n")
 	out.WriteString("\t_ \"embed\"\n")
 	out.WriteString("\t\"fyne.io/fyne/v2\"\n")
-	out.WriteString(")\n\n")
+	out.WriteString(")\n")
 }
 
 func writeResource(file, name string, f *os.File) {
-	_, err := fmt.Fprintf(f, "//go:embed %s\nvar %sData []byte\n", file, name)
+	_, err := fmt.Fprintf(f, "\n//go:embed %s\nvar %sData []byte\n", file, name)
 	if err != nil {
 		fyne.LogError("Unable to write to bundled file", err)
 	}
 
-	const format = "var %s = &fyne.StaticResource{\n\tStaticName: %q,\n\tStaticContent: %sData,\n}\n"
+	const format = "var %s = &fyne.StaticResource{\n\tStaticName:    %q,\n\tStaticContent: %sData,\n}\n"
 	_, err = fmt.Fprintf(f, format, name, file, name)
 	if err != nil {
 		fyne.LogError("Unable to write to bundled file", err)

--- a/cmd/fyne/internal/commands/bundle_test.go
+++ b/cmd/fyne/internal/commands/bundle_test.go
@@ -44,7 +44,7 @@ func TestWriteResource(t *testing.T) {
 	writeResource("testdata/bundle/content.txt", "contentTxt", f)
 
 	const header = fileHeader + "\n\npackage test\n\nimport (\n\t_ \"embed\"\n\t\"fyne.io/fyne/v2\"\n)\n\n"
-	const expected = header + "//go:embed testdata/bundle/content.txt\nvar contentTxtData []byte\nvar contentTxt = &fyne.StaticResource{\n\tStaticName: \"testdata/bundle/content.txt\",\n\tStaticContent: contentTxtData,\n}\n"
+	const expected = header + "//go:embed testdata/bundle/content.txt\nvar contentTxtData []byte\nvar contentTxt = &fyne.StaticResource{\n\tStaticName:    \"testdata/bundle/content.txt\",\n\tStaticContent: contentTxtData,\n}\n"
 
 	// Seek file to start so we can read the written data.
 	_, err = f.Seek(0, io.SeekStart)


### PR DESCRIPTION
Put a space between each embed, update the indentation of the field values.