### PR TITLE
Don't stop if there is no metadata file

### DIFF
--- a/cmd/fyne/internal/commands/install.go
+++ b/cmd/fyne/internal/commands/install.go
@@ -224,10 +224,12 @@ func (i *Installer) installRemote(ctx *cli.Context) error {
 
 	if i.icon == "" {
 		meta, err := metadata.LoadStandard(path)
-		if err != nil {
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
 			return fmt.Errorf("failed to load metadata: %w", err)
 		}
-		i.icon = filepath.Join(path, meta.Details.Icon)
+		if meta != nil {
+			i.icon = filepath.Join(path, meta.Details.Icon)
+		}
 	}
 	i.srcDir = path
 	i.release = true


### PR DESCRIPTION
This should address https://github.com/fyne-io/tools/issues/85 and show the real error (no icon) instead of choking on the missing FyneApp.toml.