### PR TITLE
Don't generate Migration code for pre-2.6 library usage

### DIFF
--- a/cmd/fyne/internal/commands/build.go
+++ b/cmd/fyne/internal/commands/build.go
@@ -346,6 +346,10 @@ func injectMetadataIfPossible(runner runner, srcdir string, app *appData,
 	if fyneGoModVersionAtLeast2_3.Match(fyneGoModVersion) {
 		app.VersionAtLeast2_3 = true
 	}
+	fyneGoModVersionAtLeast2_6 := version.NewConstrainGroupFromString(">=2.6")
+	if fyneGoModVersionAtLeast2_6.Match(fyneGoModVersion) {
+		app.VersionAtLeast2_6 = true
+	}
 
 	return createMetadataInitFile(srcdir, app)
 }

--- a/cmd/fyne/internal/commands/data.go
+++ b/cmd/fyne/internal/commands/data.go
@@ -11,6 +11,7 @@ type appData struct {
 	CustomMetadata    map[string]string
 	Migrations        map[string]bool
 	VersionAtLeast2_3 bool
+	VersionAtLeast2_6 bool
 }
 
 func (a *appData) appendCustomMetadata(fromFile map[string]string) {

--- a/cmd/fyne/internal/templates/data/fyne_metadata_init.got
+++ b/cmd/fyne/internal/templates/data/fyne_metadata_init.got
@@ -19,6 +19,8 @@ func init() {
 			"{{$key}}": "{{$value}}",
 			{{end}}
 		},
+		{{end}}
+		{{if .VersionAtLeast2_6}}
 		Migrations: map[string]bool{
         	{{range $key, $value := .Migrations}}
         	"{{$key}}": {{$value}},


### PR DESCRIPTION
The latest fyne CLI will generate fyne_metadata.go that contains a `Migrations` section. 
This will fail to compile if the library on the project is before v2.6.0.
This change means we only generate that if the library is capable.