### PR TITLE
Improve bundle help to show that at least one file is needed

### DIFF
--- a/cmd/fyne/internal/commands/bundle.go
+++ b/cmd/fyne/internal/commands/bundle.go
@@ -25,6 +25,7 @@ func Bundle() *cli.Command {
 	return &cli.Command{
 		Name:        "bundle",
 		Usage:       "Embeds static content into your go application",
+		ArgsUsage:   "file ...",
 		Description: "Each resource will have a generated filename unless specified.",
 		Flags: []cli.Flag{
 			&cli.StringFlag{


### PR DESCRIPTION
Since the first argument to `fyne bundle` is mandatory, the current version of the help/usage is misleading, and this change aligns it:

Before:
```
USAGE:
   fyne bundle [command options] [arguments...]
```

After:
```
USAGE:
   fyne bundle [command options] file ...
```