### PR TITLE
Set StartupWMClass in Unix/Linux .desktop files

### DIFF
--- a/cmd/fyne/internal/commands/package-unix.go
+++ b/cmd/fyne/internal/commands/package-unix.go
@@ -13,17 +13,18 @@ import (
 )
 
 type unixData struct {
-	Name        string
-	AppID       string
-	Exec        string
-	Icon        string
-	Local       string
-	GenericName string
-	Categories  string
-	Comment     string
-	Keywords    string
-	ExecParams  string
-	MimeTypes   string
+	Name           string
+	AppID          string
+	Exec           string
+	Icon           string
+	Local          string
+	GenericName    string
+	Categories     string
+	Comment        string
+	Keywords       string
+	ExecParams     string
+	MimeTypes      string
+	StartupWMClass string
 
 	SourceRepo, SourceDir string
 }
@@ -88,17 +89,18 @@ func (p *Packager) packageUNIX() error {
 		linuxBSD = *p.linuxAndBSDMetadata
 	}
 	tplData := unixData{
-		Name:        p.Name,
-		AppID:       p.AppID,
-		Exec:        filepath.Base(p.exe) + openWith,
-		Icon:        appIDOrName,
-		Local:       local,
-		GenericName: linuxBSD.GenericName,
-		Keywords:    formatDesktopFileList(linuxBSD.Keywords),
-		Comment:     linuxBSD.Comment,
-		Categories:  formatDesktopFileList(linuxBSD.Categories),
-		ExecParams:  linuxBSD.ExecParams,
-		MimeTypes:   mimes,
+		Name:           p.Name,
+		AppID:          p.AppID,
+		Exec:           filepath.Base(p.exe) + openWith,
+		Icon:           appIDOrName,
+		Local:          local,
+		GenericName:    linuxBSD.GenericName,
+		Keywords:       formatDesktopFileList(linuxBSD.Keywords),
+		Comment:        linuxBSD.Comment,
+		Categories:     formatDesktopFileList(linuxBSD.Categories),
+		ExecParams:     linuxBSD.ExecParams,
+		MimeTypes:      mimes,
+		StartupWMClass: p.Name,
 	}
 
 	if p.sourceMetadata != nil {

--- a/cmd/fyne/internal/commands/package-unix_test.go
+++ b/cmd/fyne/internal/commands/package-unix_test.go
@@ -47,3 +47,15 @@ func TestDesktopFileOpenWith(t *testing.T) {
 	assert.Nil(t, err)
 	assert.True(t, strings.Contains(buf.String(), "MimeType=text/plain"))
 }
+
+func TestDesktopFile(t *testing.T) {
+	tplData := unixData{
+		Name:           "Testing",
+		StartupWMClass: "Testing",
+	}
+	buf := &bytes.Buffer{}
+
+	err := templates.DesktopFileUNIX.Execute(buf, tplData)
+	assert.Nil(t, err)
+	assert.True(t, strings.Contains(buf.String(), "StartupWMClass=Testing"))
+}

--- a/cmd/fyne/internal/templates/data/entry.desktop
+++ b/cmd/fyne/internal/templates/data/entry.desktop
@@ -21,3 +21,7 @@ Repo={{.SourceRepo}}
 Dir={{.SourceDir}}
 
 {{end -}}
+{{if ne .StartupWMClass "" -}}
+StartupWMClass={{.StartupWMClass}}
+
+{{end -}}


### PR DESCRIPTION
### Description:
This change adds StartupWMClass to the Unix/Linux  .desktop file, which links the running application to the installed shortcut.
This change fixes this on Ubuntu 24.04 for me

- [x] Tests included.
- [x] Tests all pass.
