### PR TITLE
gendex: Sort directory names in findLast

### DIFF
--- a/cmd/fyne/internal/mobile/gendex/gendex.go
+++ b/cmd/fyne/internal/mobile/gendex/gendex.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 )
 
 var outfile = flag.String("o", "dex.go", "result will be written file")
@@ -141,6 +142,7 @@ func findLast(path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	sort.Strings(children)
 	return path + "/" + children[len(children)-1], nil
 }
 


### PR DESCRIPTION
`findLast` returns the last subfolder for a given directory but the subfolders are in random order.

`fmt.Println(children)` prints for example:

```
[android-32 android-36.1 android-25 android-29 android-33 android-31 android-34 android-36 android-35 android-28 android-30]
[35.0.0 36.1.0-rc1 36.0.0 33.0.1 28.0.3 36.1.0 34.0.0]
```

With this PR, the subfolders are sorted (in alphabetical order) before the last one is picked.