### PR TITLE
Let the compiler handle the flag instead of bypassing it

### DIFF
--- a/cmd/fyne/internal/commands/build.go
+++ b/cmd/fyne/internal/commands/build.go
@@ -21,7 +21,7 @@ import (
 const (
 	baseCFLAGSRegular      = "-O2 -g -fexceptions -fasynchronous-unwind-tables -pipe"
 	baseCFLAGSRelease      = "-O3 -pipe"
-	hardeningCFLAGS        = "-Wp,-D_FORTIFY_SOURCE=3 -fstack-protector-strong"
+	hardeningCFLAGS        = "-D_FORTIFY_SOURCE=3 -fstack-protector-strong"
 	hardeningLDFLAGSLinux  = "-Wl,-z,relro,-z,now -Wl,--as-needed"
 	hardeningLDFLAGSDarwin = "-Wl,-dead_strip_dylibs"
 )


### PR DESCRIPTION

Explanation: https://gcc.gnu.org/onlinedocs/gcc/Preprocessor-Options.html#index-Wp

Should fix zig compilation:
```
...
/usr/bin/docker run --rm -t -w /app -v /home/simon/Code/fyne-foo:/app:z -v /home/simon/.cache/fyne-cross:/go:z --platform linux/arm64 --user 1000 -e HOME=/tmp -e CGO_ENABLED=1 -e GOCACHE=/go/go-build -e GOARCH=arm64 -e CC=zig cc -target aarch64-linux-gnu -isystem /usr/include -L/usr/lib/aarch64-linux-gnu -e CXX=zig c++ -target aarch64-linux-gnu -isystem /usr/include -L/usr/lib/aarch64-linux-gnu -e GOOS=linux 5cf1b4d6f8bf /usr/local/bin/fyne package -os linux -name fyne-foo -icon /app/fyne-cross/tmp/linux-arm64/Icon.png -app-build 1 -app-version 0.0.0 -id fyne_foo -release
# runtime/cgo
error: unsupported preprocessor arg: -D_FORTIFY_SOURCE

error building application: exit status 1
[✗] could not package the Fyne app: could not package the Fyne app: exit status 1
```