### PR TITLE
Disable control flow protection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 This file lists the main changes with each version of the Fyne tools project.
 More detailed release notes can be found on the [releases page](https://github.com/fyne-io/tools/releases).
 
-## 1.7.2 - 28 May 2026
+## 1.7.2 - 29 May 2026
 
 ### Changed
 
@@ -12,6 +12,7 @@ More detailed release notes can be found on the [releases page](https://github.c
 ### Fixed
 
 * Pass flag to compiler instead of preprocessor directly (#129)
+* Build with compilers missing support flow-control protection (#133)
 
 
 ## 1.7.1 - 12 Apr 2026

--- a/cmd/fyne/internal/commands/build.go
+++ b/cmd/fyne/internal/commands/build.go
@@ -313,8 +313,6 @@ func (b *Builder) applyCAndLDFlags(env *[]string, goos string) {
 	}
 
 	switch targetArch() {
-	case "amd64":
-		cflags = append(cflags, "-fcf-protection")
 	case "arm64":
 		cflags = append(cflags, "-mbranch-protection=bti+pac-ret")
 	}

--- a/cmd/fyne/internal/commands/build_test.go
+++ b/cmd/fyne/internal/commands/build_test.go
@@ -77,8 +77,6 @@ func Test_BuildLinuxReleaseVersion(t *testing.T) {
 
 	archcflags := ""
 	switch targetArch() {
-	case "amd64":
-		archcflags = " -fcf-protection"
 	case "arm64":
 		archcflags = " -mbranch-protection=bti+pac-ret"
 	}


### PR DESCRIPTION
Fixes the build with compilers that don't support flow-control protection flags.