### PR TITLE
Fix 'fyne package' embedding of Windows metadata and icon when outputting to a different directory

### DIFF
--- a/cmd/fyne/internal/commands/package-windows.go
+++ b/cmd/fyne/internal/commands/package-windows.go
@@ -70,7 +70,7 @@ func (p *Packager) packageWindows(tags []string) error {
 	}
 
 	// launch rsrc to generate the object file
-	outPath := filepath.Join(exePath, "fyne.syso")
+	outPath := filepath.Join(p.srcDir, "fyne.syso")
 
 	vi := &goversioninfo.VersionInfo{}
 	vi.ProductName = p.Name


### PR DESCRIPTION
From the `goversioninfo` [README](https://github.com/josephspurrier/goversioninfo):

```
Go will automatically use the syso file if it's in the same directory as the main() function.
```

Change the directory the .syso file is created in to be the source directory, not the output directory, which may be different.

Resolves my part of #108. I suspect the original issue is caused by a similar bug, but I couldn't quickly find it and haven't tested that this covers it.