### PR TITLE
Fix: use application name as AppID if not specified during Unix package build

### DIFF
--- a/cmd/fyne/internal/commands/package-unix.go
+++ b/cmd/fyne/internal/commands/package-unix.go
@@ -90,7 +90,7 @@ func (p *Packager) packageUNIX() error {
 	}
 	tplData := unixData{
 		Name:           p.Name,
-		AppID:          p.AppID,
+		AppID:          appIDOrName,
 		Exec:           filepath.Base(p.exe) + openWith,
 		Icon:           appIDOrName,
 		Local:          local,


### PR DESCRIPTION
This PR fixes an issue where building a Unix package without specifying an AppID led to a Makefile containing an empty AppID variable, causing make failures. The tool now correctly falls back to the application name if AppID is not provided.