### PR TITLE
Compiler/platform based optimisation flags

### DIFF
--- a/cmd/fyne/internal/commands/build.go
+++ b/cmd/fyne/internal/commands/build.go
@@ -21,9 +21,6 @@ import (
 const (
 	baseCFLAGSRegular      = "-O2 -g -fexceptions -fasynchronous-unwind-tables -pipe"
 	baseCFLAGSRelease      = "-O3 -pipe"
-	hardeningCFLAGS        = "-D_FORTIFY_SOURCE=3 -fstack-protector-strong"
-	hardeningLDFLAGSLinux  = "-Wl,-z,relro,-z,now -Wl,--as-needed"
-	hardeningLDFLAGSDarwin = "-Wl,-dead_strip_dylibs"
 )
 
 // Builder generate the executables.
@@ -296,9 +293,15 @@ func (b *Builder) updateAndGetGoExecutable() runner {
 }
 
 func (b *Builder) applyCAndLDFlags(env *[]string, goos string) {
-	cflags := []string{baseCFLAGSRegular, hardeningCFLAGS}
+	cflags := []string{baseCFLAGSRegular}
 	if b.release {
 		cflags[0] = baseCFLAGSRelease
+	}
+
+	arch := targetArch()
+	cflagsHardening := hardeningFlagsLookup(ccVersion(), arch, goos)
+	if cflagsHardening != "" {
+		cflags = append(cflags, cflagsHardening)
 	}
 
 	ldflags := []string{}
@@ -312,7 +315,7 @@ func (b *Builder) applyCAndLDFlags(env *[]string, goos string) {
 		ldflags = append(ldflags, "-mmacosx-version-min=10.13")
 	}
 
-	switch targetArch() {
+	switch arch {
 	case "arm64":
 		cflags = append(cflags, "-mbranch-protection=bti+pac-ret")
 	}

--- a/cmd/fyne/internal/commands/build.go
+++ b/cmd/fyne/internal/commands/build.go
@@ -19,8 +19,8 @@ import (
 
 // Partly based on https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/blob/master/include/flags.yml?ref_type=heads.
 const (
-	baseCFLAGSRegular      = "-O2 -g -fexceptions -fasynchronous-unwind-tables -pipe"
-	baseCFLAGSRelease      = "-O3 -pipe"
+	baseCFLAGSRegular = "-O2 -g -fexceptions -fasynchronous-unwind-tables -pipe"
+	baseCFLAGSRelease = "-O3 -pipe"
 )
 
 // Builder generate the executables.

--- a/cmd/fyne/internal/commands/build.go
+++ b/cmd/fyne/internal/commands/build.go
@@ -299,7 +299,7 @@ func (b *Builder) applyCAndLDFlags(env *[]string, goos string) {
 	}
 
 	arch := targetArch()
-	cflagsHardening := hardeningFlagsLookup(ccVersion(), arch, goos)
+	cflagsHardening := hardeningCFlagsLookup(ccVersion(), arch, goos)
 	if cflagsHardening != "" {
 		cflags = append(cflags, cflagsHardening)
 	}

--- a/cmd/fyne/internal/commands/hardening_flags.go
+++ b/cmd/fyne/internal/commands/hardening_flags.go
@@ -20,7 +20,7 @@ type hardeningFlags struct {
 }
 
 var hardeningFlagsTable = []hardeningFlags{
-	{"ubuntu", "amd64", "gcc", "*", "11.4.0", "-fcf-protection -fstack-protector-strong"}, // https://github.com/fyne-io/tools/issues/137
+	{"ubuntu", "amd64", "gcc", "*", "11.4.0", "-fcf-protection -fstack-protector-strong"}, // Ubuntu 22.04/gcc 11.4.0 fails with _FORTIFY_SOURCE redefined error
 	{"windows", "*", "gcc", "*", "*", "-D_FORTIFY_SOURCE=3 -fstack-protector-strong"},     // mingw doesn't support -fcf-protection -- XXX: double check for better conditions
 }
 

--- a/cmd/fyne/internal/commands/hardening_flags.go
+++ b/cmd/fyne/internal/commands/hardening_flags.go
@@ -1,0 +1,62 @@
+package commands
+
+import (
+	"os"
+	"os/exec"
+
+	"golang.org/x/mod/semver"
+
+	intutil "fyne.io/tools/cmd/fyne/internal/util"
+)
+
+const (
+	hardeningCFLAGS        = "-D_FORTIFY_SOURCE=3 -fstack-protector-strong"
+	hardeningLDFLAGSLinux  = "-Wl,-z,relro,-z,now -Wl,--as-needed"
+	hardeningLDFLAGSDarwin = "-Wl,-dead_strip_dylibs"
+)
+
+type hardeningFlags struct {
+	os, arch, cc, minVer, maxVer, cflags string
+}
+
+var hardeningFlagsTable = []hardeningFlags{
+	{"ubuntu", "amd64", "gcc", "0", "11.4.0", "-fstack-protector-strong"},
+}
+
+func ccVersion() string {
+	cc, ok := os.LookupEnv("CC")
+	if !ok {
+		cc = "cc"
+	}
+
+	cmd := exec.Command(cc, "--version")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return ""
+	}
+
+	return string(out)
+}
+
+func hardeningFlagsLookup(out, goos, arch string) string {
+	info, err := intutil.DetectCompiler(out, goos)
+	if err != nil {
+		return ""
+	}
+	for _, e := range hardeningFlagsTable {
+		if e.os != info.OS {
+			continue
+		}
+		if e.arch != arch {
+			continue
+		}
+		if semver.Compare("v"+info.Version, "v"+e.minVer) < 0 {
+			continue
+		}
+		if semver.Compare("v"+info.Version, "v"+e.maxVer) > 0 {
+			continue
+		}
+		return e.cflags
+	}
+	return hardeningCFLAGS
+}

--- a/cmd/fyne/internal/commands/hardening_flags.go
+++ b/cmd/fyne/internal/commands/hardening_flags.go
@@ -10,8 +10,8 @@ import (
 )
 
 const (
-	hardeningCFLAGS = "-D_FORTIFY_SOURCE=3 -fstack-protector-strong"
-	hardeningLDFLAGSLinux = "-Wl,-z,relro,-z,now -Wl,--as-needed"
+	hardeningCFLAGS        = "-D_FORTIFY_SOURCE=3 -fstack-protector-strong"
+	hardeningLDFLAGSLinux  = "-Wl,-z,relro,-z,now -Wl,--as-needed"
 	hardeningLDFLAGSDarwin = "-Wl,-dead_strip_dylibs"
 )
 

--- a/cmd/fyne/internal/commands/hardening_flags.go
+++ b/cmd/fyne/internal/commands/hardening_flags.go
@@ -39,7 +39,7 @@ func ccVersion() string {
 	return string(out)
 }
 
-func hardeningFlagsLookup(out, goos, arch string) string {
+func hardeningCFlagsLookup(out, goos, arch string) string {
 	info, err := intutil.DetectCompiler(out, goos)
 	if err != nil {
 		return ""

--- a/cmd/fyne/internal/commands/hardening_flags.go
+++ b/cmd/fyne/internal/commands/hardening_flags.go
@@ -20,7 +20,7 @@ type hardeningFlags struct {
 }
 
 var hardeningFlagsTable = []hardeningFlags{
-	{"ubuntu", "amd64", "gcc", "0", "11.4.0", "-fstack-protector-strong"},
+	{"ubuntu", "amd64", "gcc", "0", "11.4.0", "-fstack-protector-strong"}, // https://github.com/fyne-io/tools/issues/137
 }
 
 func ccVersion() string {

--- a/cmd/fyne/internal/commands/hardening_flags.go
+++ b/cmd/fyne/internal/commands/hardening_flags.go
@@ -10,8 +10,8 @@ import (
 )
 
 const (
-	hardeningCFLAGS        = "-D_FORTIFY_SOURCE=3 -fstack-protector-strong"
-	hardeningLDFLAGSLinux  = "-Wl,-z,relro,-z,now -Wl,--as-needed"
+	hardeningCFLAGS = "-D_FORTIFY_SOURCE=3 -fstack-protector-strong"
+	hardeningLDFLAGSLinux = "-Wl,-z,relro,-z,now -Wl,--as-needed"
 	hardeningLDFLAGSDarwin = "-Wl,-dead_strip_dylibs"
 )
 

--- a/cmd/fyne/internal/commands/hardening_flags.go
+++ b/cmd/fyne/internal/commands/hardening_flags.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	hardeningCFLAGS        = "-D_FORTIFY_SOURCE=3 -fstack-protector-strong"
+	hardeningCFLAGS        = "-D_FORTIFY_SOURCE=3 -fcf-protection -fstack-protector-strong"
 	hardeningLDFLAGSLinux  = "-Wl,-z,relro,-z,now -Wl,--as-needed"
 	hardeningLDFLAGSDarwin = "-Wl,-dead_strip_dylibs"
 )
@@ -20,7 +20,8 @@ type hardeningFlags struct {
 }
 
 var hardeningFlagsTable = []hardeningFlags{
-	{"ubuntu", "amd64", "gcc", "0", "11.4.0", "-fstack-protector-strong"}, // https://github.com/fyne-io/tools/issues/137
+	{"ubuntu", "amd64", "gcc", "*", "11.4.0", "-fcf-protection -fstack-protector-strong"}, // https://github.com/fyne-io/tools/issues/137
+	{"windows", "*", "gcc", "*", "*", "-D_FORTIFY_SOURCE=3 -fstack-protector-strong"},     // mingw doesn't support -fcf-protection -- XXX: double check for better conditions
 }
 
 func ccVersion() string {
@@ -44,16 +45,19 @@ func hardeningFlagsLookup(out, goos, arch string) string {
 		return ""
 	}
 	for _, e := range hardeningFlagsTable {
-		if e.os != info.OS {
+		if e.cc != "*" && e.cc != info.Name {
 			continue
 		}
-		if e.arch != arch {
+		if e.os != "*" && e.os != info.OS {
 			continue
 		}
-		if semver.Compare("v"+info.Version, "v"+e.minVer) < 0 {
+		if e.arch != "*" && e.arch != arch {
 			continue
 		}
-		if semver.Compare("v"+info.Version, "v"+e.maxVer) > 0 {
+		if e.minVer != "*" && semver.Compare("v"+info.Version, "v"+e.minVer) < 0 {
+			continue
+		}
+		if e.maxVer != "*" && semver.Compare("v"+info.Version, "v"+e.maxVer) > 0 {
 			continue
 		}
 		return e.cflags

--- a/cmd/fyne/internal/commands/hardening_flags_test.go
+++ b/cmd/fyne/internal/commands/hardening_flags_test.go
@@ -1,0 +1,17 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_hardeningFlagsLookup(t *testing.T) {
+	assert.Equal(t, "", hardeningFlagsLookup("", "ubuntu", "amd64"))
+	assert.Equal(t, "-fstack-protector-strong", hardeningFlagsLookup("clang version 11.3.0", "ubuntu", "amd64"))
+	assert.Equal(t, "-fstack-protector-strong", hardeningFlagsLookup("clang version 11.4.0", "ubuntu", "amd64"))
+	assert.Equal(t, "-D_FORTIFY_SOURCE=3 -fstack-protector-strong", hardeningFlagsLookup("clang version 11.4.1", "ubuntu", "amd64"))
+	assert.Equal(t, "-D_FORTIFY_SOURCE=3 -fstack-protector-strong", hardeningFlagsLookup("clang version 11.4.0", "ubuntu", "arm64"))
+	assert.Equal(t, hardeningCFLAGS, hardeningFlagsLookup("clang version 1.2.3", "darwin", "arm"))
+	assert.Equal(t, hardeningCFLAGS, hardeningFlagsLookup("cc (Whatever) 1.2.3", "linux", "i386"))
+}

--- a/cmd/fyne/internal/commands/hardening_flags_test.go
+++ b/cmd/fyne/internal/commands/hardening_flags_test.go
@@ -6,28 +6,28 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_hardeningFlagsLookup(t *testing.T) {
+func Test_hardeningCFlagsLookup(t *testing.T) {
 	// no compiler, no flags
-	assert.Equal(t, "", hardeningFlagsLookup("", "ubuntu", "amd64"))
+	assert.Equal(t, "", hardeningCFlagsLookup("", "ubuntu", "amd64"))
 
 	// compiler version lower or equal
-	assert.Equal(t, "-fcf-protection -fstack-protector-strong", hardeningFlagsLookup("cc (Ubuntu) 11.3.0", "ubuntu", "amd64"))
-	assert.Equal(t, "-fcf-protection -fstack-protector-strong", hardeningFlagsLookup("cc (Ubuntu) 11.4.0", "ubuntu", "amd64"))
+	assert.Equal(t, "-fcf-protection -fstack-protector-strong", hardeningCFlagsLookup("cc (Ubuntu) 11.3.0", "ubuntu", "amd64"))
+	assert.Equal(t, "-fcf-protection -fstack-protector-strong", hardeningCFlagsLookup("cc (Ubuntu) 11.4.0", "ubuntu", "amd64"))
 
 	// compiler version higher
-	assert.Equal(t, hardeningCFLAGS, hardeningFlagsLookup("clang version 11.4.1", "ubuntu", "amd64"))
+	assert.Equal(t, hardeningCFLAGS, hardeningCFlagsLookup("clang version 11.4.1", "ubuntu", "amd64"))
 
 	// different compiler
-	assert.Equal(t, hardeningCFLAGS, hardeningFlagsLookup("clang version 11.3.0", "ubuntu", "amd64"))
-	assert.Equal(t, hardeningCFLAGS, hardeningFlagsLookup("clang version 11.4.0", "ubuntu", "amd64"))
+	assert.Equal(t, hardeningCFLAGS, hardeningCFlagsLookup("clang version 11.3.0", "ubuntu", "amd64"))
+	assert.Equal(t, hardeningCFLAGS, hardeningCFlagsLookup("clang version 11.4.0", "ubuntu", "amd64"))
 
 	// different arch
-	assert.Equal(t, hardeningCFLAGS, hardeningFlagsLookup("cc (Ubuntu) 11.4.0", "ubuntu", "arm64"))
+	assert.Equal(t, hardeningCFLAGS, hardeningCFlagsLookup("cc (Ubuntu) 11.4.0", "ubuntu", "arm64"))
 
 	// no specific flags
-	assert.Equal(t, hardeningCFLAGS, hardeningFlagsLookup("clang version 1.2.3", "darwin", "arm"))
-	assert.Equal(t, hardeningCFLAGS, hardeningFlagsLookup("cc (Whatever) 1.2.3", "linux", "i386"))
+	assert.Equal(t, hardeningCFLAGS, hardeningCFlagsLookup("clang version 1.2.3", "darwin", "arm"))
+	assert.Equal(t, hardeningCFLAGS, hardeningCFlagsLookup("cc (Whatever) 1.2.3", "linux", "i386"))
 
 	// windows/mingw lacks -fcf-protection support
-	assert.Equal(t, "-D_FORTIFY_SOURCE=3 -fstack-protector-strong", hardeningFlagsLookup("cc (GCC) 2.3.4", "windows", "i386"))
+	assert.Equal(t, "-D_FORTIFY_SOURCE=3 -fstack-protector-strong", hardeningCFlagsLookup("cc (GCC) 2.3.4", "windows", "i386"))
 }

--- a/cmd/fyne/internal/commands/hardening_flags_test.go
+++ b/cmd/fyne/internal/commands/hardening_flags_test.go
@@ -15,7 +15,7 @@ func Test_hardeningCFlagsLookup(t *testing.T) {
 	assert.Equal(t, "-fcf-protection -fstack-protector-strong", hardeningCFlagsLookup("cc (Ubuntu) 11.4.0", "ubuntu", "amd64"))
 
 	// compiler version higher
-	assert.Equal(t, hardeningCFLAGS, hardeningCFlagsLookup("clang version 11.4.1", "ubuntu", "amd64"))
+	assert.Equal(t, hardeningCFLAGS, hardeningCFlagsLookup("cc (Ubuntu) 11.4.1", "ubuntu", "amd64"))
 
 	// different compiler
 	assert.Equal(t, hardeningCFLAGS, hardeningCFlagsLookup("clang version 11.3.0", "ubuntu", "amd64"))

--- a/cmd/fyne/internal/commands/hardening_flags_test.go
+++ b/cmd/fyne/internal/commands/hardening_flags_test.go
@@ -7,11 +7,27 @@ import (
 )
 
 func Test_hardeningFlagsLookup(t *testing.T) {
+	// no compiler, no flags
 	assert.Equal(t, "", hardeningFlagsLookup("", "ubuntu", "amd64"))
-	assert.Equal(t, "-fstack-protector-strong", hardeningFlagsLookup("clang version 11.3.0", "ubuntu", "amd64"))
-	assert.Equal(t, "-fstack-protector-strong", hardeningFlagsLookup("clang version 11.4.0", "ubuntu", "amd64"))
-	assert.Equal(t, "-D_FORTIFY_SOURCE=3 -fstack-protector-strong", hardeningFlagsLookup("clang version 11.4.1", "ubuntu", "amd64"))
-	assert.Equal(t, "-D_FORTIFY_SOURCE=3 -fstack-protector-strong", hardeningFlagsLookup("clang version 11.4.0", "ubuntu", "arm64"))
+
+	// compiler version lower or equal
+	assert.Equal(t, "-fcf-protection -fstack-protector-strong", hardeningFlagsLookup("cc (Ubuntu) 11.3.0", "ubuntu", "amd64"))
+	assert.Equal(t, "-fcf-protection -fstack-protector-strong", hardeningFlagsLookup("cc (Ubuntu) 11.4.0", "ubuntu", "amd64"))
+
+	// compiler version higher
+	assert.Equal(t, hardeningCFLAGS, hardeningFlagsLookup("clang version 11.4.1", "ubuntu", "amd64"))
+
+	// different compiler
+	assert.Equal(t, hardeningCFLAGS, hardeningFlagsLookup("clang version 11.3.0", "ubuntu", "amd64"))
+	assert.Equal(t, hardeningCFLAGS, hardeningFlagsLookup("clang version 11.4.0", "ubuntu", "amd64"))
+
+	// different arch
+	assert.Equal(t, hardeningCFLAGS, hardeningFlagsLookup("cc (Ubuntu) 11.4.0", "ubuntu", "arm64"))
+
+	// no specific flags
 	assert.Equal(t, hardeningCFLAGS, hardeningFlagsLookup("clang version 1.2.3", "darwin", "arm"))
 	assert.Equal(t, hardeningCFLAGS, hardeningFlagsLookup("cc (Whatever) 1.2.3", "linux", "i386"))
+
+	// windows/mingw lacks -fcf-protection support
+	assert.Equal(t, "-D_FORTIFY_SOURCE=3 -fstack-protector-strong", hardeningFlagsLookup("cc (GCC) 2.3.4", "windows", "i386"))
 }

--- a/cmd/fyne/internal/util/detect_compiler.go
+++ b/cmd/fyne/internal/util/detect_compiler.go
@@ -1,0 +1,76 @@
+package util
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+	"unicode"
+
+	"golang.org/x/mod/semver"
+)
+
+var (
+	rxClang   = regexp.MustCompile(`(?:(\S+)\s+)?clang\s+version\s+([0-9.]+)`)
+	rxGcc     = regexp.MustCompile(`\bcc(\.exe)?\s+\(([^)]+)\)\s+([0-9.]+)`)
+	rxBuiltBy = regexp.MustCompile(`built\s+by\s+(\S+)`)
+)
+
+var (
+	ErrNoCompilerFound = errors.New("failed to detect compiler")
+	ErrInvalidVersion  = errors.New("failed to parse version")
+)
+
+// CompilerInfo holds detected compiler information.
+type CompilerInfo struct {
+	Name    string
+	Version string
+	OS      string
+}
+
+// DetectCompiler takes the output of `cc --version` and tries to detect the
+// compiler, compiler version, and os name when available.
+func DetectCompiler(s, os string) (*CompilerInfo, error) {
+	osname := func(s string) string {
+		switch s {
+		case "apple":
+			return "darwin"
+		case "":
+			return os
+		}
+		return s
+	}
+
+	if m := rxClang.FindStringSubmatch(strings.ToLower(s)); len(m) == 3 {
+		if !semver.IsValid("v" + m[2]) {
+			return nil, ErrInvalidVersion
+		}
+		return &CompilerInfo{"clang", m[2], osname(m[1])}, nil
+	}
+
+	if m := rxGcc.FindStringSubmatch(strings.ToLower(s)); len(m) == 4 {
+		if !semver.IsValid("v" + m[3]) {
+			return nil, ErrInvalidVersion
+		}
+
+		if m[1] == ".exe" {
+			if x := rxBuiltBy.FindStringSubmatch(m[2]); len(x) == 2 {
+				return &CompilerInfo{"gcc", m[3], osname(x[1])}, nil
+			}
+		}
+
+		if m[2] == "" || m[2] == "gcc" {
+			return &CompilerInfo{"gcc", m[3], osname("")}, nil
+		}
+
+		o := append(strings.Fields(strings.Map(func(r rune) rune {
+			if unicode.IsLetter(r) || unicode.IsDigit(r) || unicode.IsSpace(r) {
+				return r
+			}
+			return ' '
+		}, m[2])), "")[0]
+
+		return &CompilerInfo{"gcc", m[3], osname(o)}, nil
+	}
+
+	return nil, ErrNoCompilerFound
+}

--- a/cmd/fyne/internal/util/detect_compiler_test.go
+++ b/cmd/fyne/internal/util/detect_compiler_test.go
@@ -9,147 +9,147 @@ import (
 func Test_DetectCompiler(t *testing.T) {
 	tests := []struct {
 		unameInfo string
-		osName    string
 		ccVersion string
+		osName    string
 		wantInfo  *CompilerInfo
 		wantError error
 	}{
 		// darwin
 		{
 			"Darwin 24.6.0 arm",
-			"darwin",
 			"Apple clang version 17.0.0 (clang-1700.0.13.5)",
+			"darwin",
 			&CompilerInfo{"clang", "17.0.0", "darwin"},
 			nil,
 		},
 		{
 			"Darwin 25.4.0 arm",
-			"darwin",
 			"Apple clang version 21.0.0 (clang-2100.1.1.101)",
+			"darwin",
 			&CompilerInfo{"clang", "21.0.0", "darwin"},
 			nil,
 		},
 		{
 			"Darwin 25.5.0 arm",
-			"darwin",
 			"Apple clang version 21.0.0 (clang-2100.1.1.101)",
+			"darwin",
 			&CompilerInfo{"clang", "21.0.0", "darwin"},
 			nil,
 		},
 		// freebsd
 		{
 			"FreeBSD 14.2-RELEASE amd64",
-			"freebsd",
 			"FreeBSD clang version 18.1.6 (https://github.com/llvm/llvm-project.git llvmorg-18.1.6-0-g1118c2e05e67)",
+			"freebsd",
 			&CompilerInfo{"clang", "18.1.6", "freebsd"},
 			nil,
 		},
 		{
 			"FreeBSD 15.1-RELEASE-p1 amd64",
-			"freebsd",
 			"FreeBSD clang version 19.1.7 (https://github.com/llvm/llvm-project.git llvmorg-19.1.7-0-gcd708029e0b2)",
+			"freebsd",
 			&CompilerInfo{"clang", "19.1.7", "freebsd"},
 			nil,
 		},
 		// linux
 		{
 			"Linux 6.12.0-160000.35-default x86_64",
-			"linux",
 			"cc (SUSE Linux) 15.3.0",
+			"linux",
 			&CompilerInfo{"gcc", "15.3.0", "suse"},
 			nil,
 		},
 		{
 			"Linux 6.12.86+deb13-arm64 unknown",
-			"linux",
 			"cc (Debian 14.2.0-19) 14.2.0",
+			"linux",
 			&CompilerInfo{"gcc", "14.2.0", "debian"},
 			nil,
 		},
 		{
 			"Linux 6.12.88+deb13-arm64 unknown",
-			"linux",
 			"cc (Debian 14.2.0-19) 14.2.0",
+			"linux",
 			&CompilerInfo{"gcc", "14.2.0", "debian"},
 			nil,
 		},
 		{
 			"Linux 6.12.93+rpt-rpi-v8 unknown",
-			"linux",
 			"cc (Debian 12.2.0-14+deb12u1) 12.2.0  (PI4)",
+			"linux",
 			&CompilerInfo{"gcc", "12.2.0", "debian"},
 			nil,
 		},
 		{
 			"Linux 6.18.35-gentoo-dist AMD Ryzen 7 7800X3D 8-Core Processor",
-			"linux",
 			"cc (Gentoo 15.3.0 p8) 15.3.0",
+			"linux",
 			&CompilerInfo{"gcc", "15.3.0", "gentoo"},
 			nil,
 		},
 		{
 			"Linux 7.0.3-arch1-2 unknown",
-			"linux",
 			"cc (GCC) 16.1.1 20260430",
+			"linux",
 			&CompilerInfo{"gcc", "16.1.1", "linux"},
 			nil,
 		},
 		{
 			"Linux 7.0.12-arch1-1 unknown",
-			"linux",
 			"cc (GCC) 16.1.1 20260430",
+			"linux",
 			&CompilerInfo{"gcc", "16.1.1", "linux"},
 			nil,
 		},
 		{
 			"Linux 7.1.2-arch3-1 unknown",
-			"linux",
 			"cc (GCC) 16.1.1 20260625",
+			"linux",
 			&CompilerInfo{"gcc", "16.1.1", "linux"},
 			nil,
 		},
 		{
 			"??? Ubuntu ....",
-			"linux",
 			"cc (Ubuntu 11.4.0-1ubuntu1~22.04.3) 11.4.0",
+			"linux",
 			&CompilerInfo{"gcc", "11.4.0", "ubuntu"},
 			nil,
 		},
 		// windows
 		{
 			"Microsoft Windows 11 Pro 10.0.26200.0 AMD64",
-			"windows",
 			"clang version 22.1.8 (https://github.com/llvm/llvm-project.git ca7933e47d3a3451d81e72ac174dcb5aa28b59d1)",
+			"windows",
 			&CompilerInfo{"clang", "22.1.8", "windows"},
 			nil,
 		},
 		{
 			"MSYS_NT-10.0-26200 3.6.7-f2802c5f.x86_64 unknown",
-			"windows",
 			"cc.exe (Rev13, Built by MSYS2 project) 15.2.0",
+			"windows",
 			&CompilerInfo{"gcc", "15.2.0", "msys2"},
 			nil,
 		},
 		// openbsd
 		{
 			"OpenBSD 7.3 aarch64",
-			"openbsd",
 			"OpenBSD clang version 13.0.0",
+			"openbsd",
 			&CompilerInfo{"clang", "13.0.0", "openbsd"},
 			nil,
 		},
 		// errors
 		{
 			"unknown",
-			"random",
 			"clank version 1.0.0",
+			"random",
 			nil,
 			ErrNoCompilerFound,
 		},
 		{
 			"unknown",
-			"random",
 			"tcc ( ,-a-b, -y -z ) 1.0.0",
+			"random",
 			nil,
 			ErrNoCompilerFound,
 		},
@@ -162,15 +162,15 @@ func Test_DetectCompiler(t *testing.T) {
 		},
 		{
 			"invalid gcc version",
-			"random",
 			"cc (Haha) 1.2.3.4",
+			"random",
 			nil,
 			ErrInvalidVersion,
 		},
 		{
 			"invalid clang version",
-			"random",
 			"Hehe clang version 1.2.3.4",
+			"random",
 			nil,
 			ErrInvalidVersion,
 		},

--- a/cmd/fyne/internal/util/detect_compiler_test.go
+++ b/cmd/fyne/internal/util/detect_compiler_test.go
@@ -1,0 +1,190 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_DetectCompiler(t *testing.T) {
+	tests := []struct {
+		unameInfo string
+		osName    string
+		ccVersion string
+		wantInfo  *CompilerInfo
+		wantError error
+	}{
+		// darwin
+		{
+			"Darwin 24.6.0 arm",
+			"darwin",
+			"Apple clang version 17.0.0 (clang-1700.0.13.5)",
+			&CompilerInfo{"clang", "17.0.0", "darwin"},
+			nil,
+		},
+		{
+			"Darwin 25.4.0 arm",
+			"darwin",
+			"Apple clang version 21.0.0 (clang-2100.1.1.101)",
+			&CompilerInfo{"clang", "21.0.0", "darwin"},
+			nil,
+		},
+		{
+			"Darwin 25.5.0 arm",
+			"darwin",
+			"Apple clang version 21.0.0 (clang-2100.1.1.101)",
+			&CompilerInfo{"clang", "21.0.0", "darwin"},
+			nil,
+		},
+		// freebsd
+		{
+			"FreeBSD 14.2-RELEASE amd64",
+			"freebsd",
+			"FreeBSD clang version 18.1.6 (https://github.com/llvm/llvm-project.git llvmorg-18.1.6-0-g1118c2e05e67)",
+			&CompilerInfo{"clang", "18.1.6", "freebsd"},
+			nil,
+		},
+		{
+			"FreeBSD 15.1-RELEASE-p1 amd64",
+			"freebsd",
+			"FreeBSD clang version 19.1.7 (https://github.com/llvm/llvm-project.git llvmorg-19.1.7-0-gcd708029e0b2)",
+			&CompilerInfo{"clang", "19.1.7", "freebsd"},
+			nil,
+		},
+		// linux
+		{
+			"Linux 6.12.0-160000.35-default x86_64",
+			"linux",
+			"cc (SUSE Linux) 15.3.0",
+			&CompilerInfo{"gcc", "15.3.0", "suse"},
+			nil,
+		},
+		{
+			"Linux 6.12.86+deb13-arm64 unknown",
+			"linux",
+			"cc (Debian 14.2.0-19) 14.2.0",
+			&CompilerInfo{"gcc", "14.2.0", "debian"},
+			nil,
+		},
+		{
+			"Linux 6.12.88+deb13-arm64 unknown",
+			"linux",
+			"cc (Debian 14.2.0-19) 14.2.0",
+			&CompilerInfo{"gcc", "14.2.0", "debian"},
+			nil,
+		},
+		{
+			"Linux 6.12.93+rpt-rpi-v8 unknown",
+			"linux",
+			"cc (Debian 12.2.0-14+deb12u1) 12.2.0  (PI4)",
+			&CompilerInfo{"gcc", "12.2.0", "debian"},
+			nil,
+		},
+		{
+			"Linux 6.18.35-gentoo-dist AMD Ryzen 7 7800X3D 8-Core Processor",
+			"linux",
+			"cc (Gentoo 15.3.0 p8) 15.3.0",
+			&CompilerInfo{"gcc", "15.3.0", "gentoo"},
+			nil,
+		},
+		{
+			"Linux 7.0.3-arch1-2 unknown",
+			"linux",
+			"cc (GCC) 16.1.1 20260430",
+			&CompilerInfo{"gcc", "16.1.1", "linux"},
+			nil,
+		},
+		{
+			"Linux 7.0.12-arch1-1 unknown",
+			"linux",
+			"cc (GCC) 16.1.1 20260430",
+			&CompilerInfo{"gcc", "16.1.1", "linux"},
+			nil,
+		},
+		{
+			"Linux 7.1.2-arch3-1 unknown",
+			"linux",
+			"cc (GCC) 16.1.1 20260625",
+			&CompilerInfo{"gcc", "16.1.1", "linux"},
+			nil,
+		},
+		{
+			"??? Ubuntu ....",
+			"linux",
+			"cc (Ubuntu 11.4.0-1ubuntu1~22.04.3) 11.4.0",
+			&CompilerInfo{"gcc", "11.4.0", "ubuntu"},
+			nil,
+		},
+		// windows
+		{
+			"Microsoft Windows 11 Pro 10.0.26200.0 AMD64",
+			"windows",
+			"clang version 22.1.8 (https://github.com/llvm/llvm-project.git ca7933e47d3a3451d81e72ac174dcb5aa28b59d1)",
+			&CompilerInfo{"clang", "22.1.8", "windows"},
+			nil,
+		},
+		{
+			"MSYS_NT-10.0-26200 3.6.7-f2802c5f.x86_64 unknown",
+			"windows",
+			"cc.exe (Rev13, Built by MSYS2 project) 15.2.0",
+			&CompilerInfo{"gcc", "15.2.0", "msys2"},
+			nil,
+		},
+		// openbsd
+		{
+			"OpenBSD 7.3 aarch64",
+			"openbsd",
+			"OpenBSD clang version 13.0.0",
+			&CompilerInfo{"clang", "13.0.0", "openbsd"},
+			nil,
+		},
+		// errors
+		{
+			"unknown",
+			"random",
+			"clank version 1.0.0",
+			nil,
+			ErrNoCompilerFound,
+		},
+		{
+			"unknown",
+			"random",
+			"tcc ( ,-a-b, -y -z ) 1.0.0",
+			nil,
+			ErrNoCompilerFound,
+		},
+		{
+			"empty",
+			"",
+			"",
+			nil,
+			ErrNoCompilerFound,
+		},
+		{
+			"invalid gcc version",
+			"random",
+			"cc (Haha) 1.2.3.4",
+			nil,
+			ErrInvalidVersion,
+		},
+		{
+			"invalid clang version",
+			"random",
+			"Hehe clang version 1.2.3.4",
+			nil,
+			ErrInvalidVersion,
+		},
+	}
+
+	for _, test := range tests {
+		info, err := DetectCompiler(test.ccVersion, test.osName)
+		if test.wantError == nil {
+			assert.NoError(t, err)
+			assert.Equal(t, test.wantInfo.Name, info.Name, "name: %s: %q", test.unameInfo, test.ccVersion)
+			assert.Equal(t, test.wantInfo.Version, info.Version, "version: %s: %q", test.unameInfo, test.ccVersion)
+			assert.Equal(t, test.wantInfo.OS, info.OS, "os: %s: %q", test.unameInfo, test.ccVersion)
+		} else if assert.Error(t, err) {
+			assert.Equal(t, test.wantError, err)
+		}
+	}
+}

--- a/cmd/fyne/internal/util/detect_compiler_test.go
+++ b/cmd/fyne/internal/util/detect_compiler_test.go
@@ -8,9 +8,9 @@ import (
 
 func Test_DetectCompiler(t *testing.T) {
 	tests := []struct {
-		unameInfo string
-		ccVersion string
-		osName    string
+		unameInfo string // uname -prs
+		ccVersion string // cc --version
+		osName    string // runtime.GOOS
 		wantInfo  *CompilerInfo
 		wantError error
 	}{


### PR DESCRIPTION
Add function to detect compiler information and use it for a lookup table with platform specific optimisation flags. Should fix https://github.com/fyne-io/tools/issues/137.