### PR TITLE
Ensure we list the most recent versions last to resolve correctly

### DIFF
--- a/cmd/fyne/internal/commands/install.go
+++ b/cmd/fyne/internal/commands/install.go
@@ -144,7 +144,7 @@ func getPackageAndBranch(s string) (string, string) {
 }
 
 func getLatestTag(repo string) (string, error) {
-	cmd := exec.Command("git", "ls-remote", "-q", repo)
+	cmd := exec.Command("git", "ls-remote", "-q", "--sort", "v:refname", repo)
 	b, err := cmd.Output()
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Reported as failure to find latest version of github.com/limafresh/TarasMessenger when it jumped from v0.9.0 to v0.10.0