### PR TITLE
Don't rely on an empty AppID, it's optional

### DIFF
--- a/cmd/fyne/internal/templates/data/Makefile
+++ b/cmd/fyne/internal/templates/data/Makefile
@@ -5,7 +5,7 @@ LOCAL != test -d $(DESTDIR)/usr/local && echo -n "/local" || echo -n ""
 LOCAL ?= $(shell test -d $(DESTDIR)/usr/local && echo "/local" || echo "")
 PREFIX ?= /usr$(LOCAL)
 
-AppID := {{ .AppID | printf "%q" }}
+AppID := {{ or .AppID .Name | printf "%q" }}
 Exec := {{ .Exec | printf "%q" }}
 Icon := {{ .Icon | printf "%q" }}
 


### PR DESCRIPTION
Fall back to .Name

Fixes #142