### PR TITLE
Fix compiler detection

### DIFF
--- a/cmd/fyne/internal/commands/build.go
+++ b/cmd/fyne/internal/commands/build.go
@@ -299,7 +299,7 @@ func (b *Builder) applyCAndLDFlags(env *[]string, goos string) {
 	}
 
 	arch := targetArch()
-	cflagsHardening := hardeningCFlagsLookup(ccVersion(), arch, goos)
+	cflagsHardening := hardeningCFlagsLookup(ccVersion(), goos, arch)
 	if cflagsHardening != "" {
 		cflags = append(cflags, cflagsHardening)
 	}

--- a/cmd/fyne/internal/commands/build_test.go
+++ b/cmd/fyne/internal/commands/build_test.go
@@ -76,11 +76,13 @@ func Test_BuildLinuxReleaseVersion(t *testing.T) {
 	}
 
 	archcflags := ""
-	switch targetArch() {
+	arch := targetArch()
+	switch arch {
 	case "arm64":
 		archcflags = " -mbranch-protection=bti+pac-ret"
 	}
 
+	hardeningCFlags := hardeningCFlagsLookup(ccVersion(), "linux", arch)
 	expected := []mockRunner{
 		{
 			expectedValue: expectedValue{args: []string{"mod", "edit", "-json"}},
@@ -91,7 +93,7 @@ func Test_BuildLinuxReleaseVersion(t *testing.T) {
 		{
 			expectedValue: expectedValue{
 				args:  []string{"build", "-trimpath", "-ldflags", "-s -w", "-tags", "release", relativePath},
-				env:   []string{"CGO_ENABLED=1", "GOOS=linux", fmt.Sprintf("CGO_CFLAGS=%s%s %s%s", cflags, baseCFLAGSRelease, hardeningCFLAGS, archcflags), fmt.Sprintf("CGO_LDFLAGS=%s%s", ldflags, hardeningLDFLAGSLinux)},
+				env:   []string{"CGO_ENABLED=1", "GOOS=linux", fmt.Sprintf("CGO_CFLAGS=%s%s %s%s", cflags, baseCFLAGSRelease, hardeningCFlags, archcflags), fmt.Sprintf("CGO_LDFLAGS=%s%s", ldflags, hardeningLDFLAGSLinux)},
 				osEnv: true,
 				dir:   "myTest",
 			},
@@ -104,7 +106,7 @@ func Test_BuildLinuxReleaseVersion(t *testing.T) {
 	linuxBuildTest := &testCommandRuns{runs: expected, t: t}
 	b := &Builder{appData: &appData{}, os: "linux", srcdir: "myTest", release: true, runner: linuxBuildTest, goPackage: relativePath}
 	err := b.build()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	linuxBuildTest.verifyExpectation()
 }
 

--- a/cmd/fyne/internal/commands/hardening_flags.go
+++ b/cmd/fyne/internal/commands/hardening_flags.go
@@ -20,8 +20,9 @@ type hardeningFlags struct {
 }
 
 var hardeningFlagsTable = []hardeningFlags{
-	{"ubuntu", "amd64", "gcc", "*", "11.4.0", "-fcf-protection -fstack-protector-strong"}, // Ubuntu 22.04/gcc 11.4.0 fails with _FORTIFY_SOURCE redefined error
-	{"windows", "*", "gcc", "*", "*", "-D_FORTIFY_SOURCE=3 -fstack-protector-strong"},     // mingw doesn't support -fcf-protection -- XXX: double check for better conditions
+	{"ubuntu", "amd64", "gcc", "*", "11.4.0", "-fcf-protection -fstack-protector-strong"},  // Ubuntu 22.04/gcc 11.4.0 fails with _FORTIFY_SOURCE redefined error
+	{"windows", "*", "gcc", "*", "*", "-D_FORTIFY_SOURCE=3 -fstack-protector-strong"},      // mingw doesn't support -fcf-protection -- XXX: double check for better conditions
+	{"darwin", "arm64", "clang", "*", "*", "-D_FORTIFY_SOURCE=3 -fstack-protector-strong"}, // -fcf-protection unsupported on this target
 }
 
 func ccVersion() string {

--- a/cmd/fyne/internal/commands/hardening_flags_test.go
+++ b/cmd/fyne/internal/commands/hardening_flags_test.go
@@ -25,9 +25,12 @@ func Test_hardeningCFlagsLookup(t *testing.T) {
 	assert.Equal(t, hardeningCFLAGS, hardeningCFlagsLookup("cc (Ubuntu) 11.4.0", "ubuntu", "arm64"))
 
 	// no specific flags
-	assert.Equal(t, hardeningCFLAGS, hardeningCFlagsLookup("clang version 1.2.3", "darwin", "arm"))
+	assert.Equal(t, hardeningCFLAGS, hardeningCFlagsLookup("clang version 1.2.3", "darwin", "amd64"))
 	assert.Equal(t, hardeningCFLAGS, hardeningCFlagsLookup("cc (Whatever) 1.2.3", "linux", "i386"))
 
 	// windows/mingw lacks -fcf-protection support
 	assert.Equal(t, "-D_FORTIFY_SOURCE=3 -fstack-protector-strong", hardeningCFlagsLookup("cc (GCC) 2.3.4", "windows", "i386"))
+
+	// darwin/arm64 doesn't do -fcf-protection
+	assert.Equal(t, "-D_FORTIFY_SOURCE=3 -fstack-protector-strong", hardeningCFlagsLookup("Apple clang version 17.0.0 (clang-1700.0.13.5)", "darwin", "arm64"))
 }


### PR DESCRIPTION
Fix argument order to make hardening flag lookup work, and adjust flags for darwin/arm64. The tests didn't catch it because there the function was called correctly already.