### PR TITLE
Fixing store compatibility for September

### DIFF
--- a/cmd/fyne/internal/mobile/build.go
+++ b/cmd/fyne/internal/mobile/build.go
@@ -30,7 +30,7 @@ var cmdBuild = &command{
 }
 
 const (
-	minAndroidAPI = 15
+	minAndroidAPI = 21
 )
 
 func runBuild(cmd *command) error {
@@ -108,7 +108,7 @@ func runBuildImpl(cmd *command) (*packages.Package, error) {
 			}
 			return pkg, nil
 		}
-		target := 35
+		target := 36
 		if !buildRelease {
 			target = 29 // TODO once we have gomobile debug signing working for v2 android signs
 		}


### PR DESCRIPTION
And updating minimum to 21 (Android 5) as a step towards matching upstream support constraints as discussed on contributor call. We need to jump further, but taking an incremental approach gets better testing.

I have tested all the system integrations and it seems like this small (jump does not break anything, but I wanted to test and after this we can go 5 -> 7.

Fixes #148