### PR TITLE
Address linter warning about ineffectual assignment to assetsDirExists

### DIFF
--- a/cmd/fyne/internal/mobile/build_androidapp.go
+++ b/cmd/fyne/internal/mobile/build_androidapp.go
@@ -215,20 +215,15 @@ func addAssets(apkw *Writer, manifestData []byte, dir, iconPath string, target i
 	}
 	arsc.iconPath = iconPath
 	assetsDir := filepath.Join(dir, "assets")
-	assetsDirExists := true
-	fi, err := os.Stat(assetsDir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			assetsDirExists = false
-		} else {
-			return err
-		}
-	} else {
+	assetsDirExists := false
+	if fi, err := os.Stat(assetsDir); err != nil && !os.IsNotExist(err) {
+		return err
+	} else if fi != nil {
 		assetsDirExists = fi.IsDir()
 	}
 	if assetsDirExists {
 		// if assets is a symlink, follow the symlink.
-		assetsDir, err = filepath.EvalSymlinks(assetsDir)
+		assetsDir, err := filepath.EvalSymlinks(assetsDir)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Copied `.golangci.yml` from the main repo and ran it in `cmd/fyne/`:
```$ golangci-lint run -v ./...
INFO golangci-lint has version 2.12.2 built with go1.25.5 from (unknown, modified: ?, mod sum: "h1:7+d1uY0bq1MU2UV3R5pW5Q7QWdcoq4naMRXM+gsJKrs=") on (unknown)
INFO [config_reader] Config search paths: [./ .../cmd/fyne .../cmd ... /]
INFO [config_reader] Used config file ../../.golangci.yml
INFO [config_reader] Module name "fyne.io/tools"
INFO [goenv] Read go env for 5.323167ms: map[string]string{"GOCACHE":".../Library/Caches/go-build", "GOROOT":"/opt/homebrew/Cellar/go/1.25.5/libexec"}
INFO [lintersdb] Active 10 linters: [errcheck gocyclo gosec govet ineffassign nolintlint revive staticcheck unconvert unused]
INFO [loader] Go packages loading at mode 8767 (types_sizes|compiled_files|deps|exports_file|files|imports|name) took 653.290625ms
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 6.211917ms
INFO [linters_context/goanalysis] analyzers took 19.52972087s with top 10 stages: buildir: 9.67960388s, revive: 3.193625751s, printf: 889.970513ms, inline: 729.852575ms, ctrlflow: 649.602118ms, fact_deprecated: 549.231092ms, SA5012: 461.434733ms, fact_purity: 435.043794ms, nilness: 431.929291ms, typedness: 410.132416ms
INFO [runner/exclusion_rules] Skipped 0 issues by rules: [Text: "SA1019", Path: "test/", Linters: "staticcheck"]
INFO [runner/exclusion_rules] Skipped 0 issues by rules: [Path: "_test\\.go", Linters: "errcheck"]
INFO [runner/exclusion_rules] Skipped 409 issues by rules: [Path: "cmd/fyne/", Linters: "errcheck, gosec, revive, staticcheck"]
INFO [runner/exclusion_rules] Skipped 0 issues by rules: [Path: "cmd/fyne_demo/", Linters: "errcheck, gosec, revive"]
INFO [runner] Issues before processing: 410, after processing: 1
INFO [runner] Processors filtering stat (in/out): path_shortener: 1/1, severity-rules: 1/1, sort_results: 1/1, cgo: 410/410, filename_unadjuster: 410/410, exclusion_paths: 410/410, max_same_issues: 1/1, exclusion_rules: 410/1, max_from_linter: 1/1, path_prettifier: 1/1, path_relativity: 410/410, generated_file_filter: 410/410, nolint_filter: 1/1, fixer: 1/1, max_per_file_from_linter: 1/1, path_absoluter: 410/410, invalid_issue: 410/410, diff: 1/1, uniq_by_line: 1/1, source_code: 1/1
INFO [runner] processing took 2.242419ms with stages: generated_file_filter: 1.100791ms, nolint_filter: 477.834µs, exclusion_rules: 279.917µs, path_relativity: 260.5µs, cgo: 64.792µs, source_code: 28.125µs, path_absoluter: 11.126µs, invalid_issue: 10.917µs, sort_results: 2.584µs, filename_unadjuster: 1.375µs, max_same_issues: 1.083µs, uniq_by_line: 1.042µs, path_shortener: 499ns, fixer: 417ns, max_from_linter: 374ns, exclusion_paths: 333ns, diff: 251ns, max_per_file_from_linter: 209ns, path_prettifier: 167ns, severity-rules: 83ns
INFO [runner] linters took 7.76732375s with stages: goanalysis_metalinter: 7.765010042s
cmd/fyne/internal/mobile/build_androidapp.go:218:2: ineffectual assignment to assetsDirExists (ineffassign)
        assetsDirExists := true
        ^
1 issues:
* ineffassign: 1
INFO File cache stats: 1 entries of total size 15.8KiB
INFO Memory: 86 samples, avg is 986.3MB, max is 1228.3MB
INFO Execution took 8.432664s
```