### PR TITLE
Address more linter issues

### DIFF
--- a/cmd/fyne/internal/commands/build.go
+++ b/cmd/fyne/internal/commands/build.go
@@ -80,7 +80,7 @@ func Build() *cli.Command {
 // Build parse the tags and start building
 func (b *Builder) Build() error {
 	if b.srcdir != "" {
-		b.srcdir = util.EnsureAbsPath(b.srcdir)
+		b.srcdir = pkgUtil.EnsureAbsPath(b.srcdir)
 		dirStat, err := os.Stat(b.srcdir)
 		if err != nil {
 			return err
@@ -213,7 +213,7 @@ func (b *Builder) computeSrcDir() (string, error) {
 func (b *Builder) updateToDefaultIconIfNotSet(srcdir string) {
 	if b.icon == "" {
 		defaultIcon := filepath.Join(srcdir, "Icon.png")
-		if util.Exists(defaultIcon) {
+		if pkgUtil.Exists(defaultIcon) {
 			b.icon = defaultIcon
 		}
 	}
@@ -290,7 +290,7 @@ func createMetadataInitFile(srcdir string, app *appData) (func(), error) {
 	if err == nil {
 		// When icon path specified in metadata file, we should make it relative to metadata file
 		if data.Details.Icon != "" {
-			data.Details.Icon = util.MakePathRelativeTo(srcdir, data.Details.Icon)
+			data.Details.Icon = pkgUtil.MakePathRelativeTo(srcdir, data.Details.Icon)
 		}
 
 		app.mergeMetadata(data)

--- a/cmd/fyne/internal/commands/bundle.go
+++ b/cmd/fyne/internal/commands/bundle.go
@@ -11,6 +11,8 @@ import (
 
 	"fyne.io/fyne/v2"
 	"github.com/urfave/cli/v2"
+
+	"fyne.io/tools/cmd/fyne/internal/util"
 )
 
 const fileHeader = "// auto-generated\n" + // to exclude this file in goreportcard (it has to be first)
@@ -111,7 +113,7 @@ func (b *Bundler) Run(args []string) {
 			fileModes = os.O_RDWR | os.O_APPEND
 		}
 
-		f, err := os.OpenFile(b.out, fileModes, 0o666)
+		f, err := os.OpenFile(b.out, fileModes, util.FilePermDefault)
 		if err == nil {
 			outFile = f
 		} else {
@@ -235,7 +237,7 @@ func openOutputFile(filePath string, noheader bool) (file *os.File, close func()
 		fileModes = os.O_RDWR | os.O_APPEND
 	}
 
-	f, err := os.OpenFile(filePath, fileModes, 0o666)
+	f, err := os.OpenFile(filePath, fileModes, util.FilePermDefault)
 	if err != nil {
 		if !os.IsNotExist(err) {
 			fyne.LogError("Unable to open output file", err)

--- a/cmd/fyne/internal/commands/flags.go
+++ b/cmd/fyne/internal/commands/flags.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/urfave/cli/v2"
@@ -15,28 +16,37 @@ func (k *keyValueFlag) Set(value string) error {
 	if k.m == nil {
 		k.m = make(map[string]string)
 	}
-	parts := strings.Split(value, "=")
+	parts := strings.SplitN(value, "=", 2)
 
 	if len(parts) < 2 {
 		return fmt.Errorf("expected format: key=value, got %s", value)
 	}
 
-	k.m[parts[0]] = strings.Join(parts[1:], "=")
+	k.m[parts[0]] = parts[1]
 	return nil
 }
 
 func (k *keyValueFlag) String() string {
-	result := ""
+	r := &strings.Builder{}
 
-	for key, value := range k.m {
-		if result == "" {
-			result = "\"" + key + "=" + value + "\""
-		} else {
-			result = result + ", \"" + key + "=" + value + "\""
+	keys := make([]string, 0, len(k.m))
+	for key := range k.m {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		if r.Len() > 0 {
+			r.WriteString(", ")
 		}
+		r.WriteByte('"')
+		r.WriteString(key)
+		r.WriteByte('=')
+		r.WriteString(k.m[key])
+		r.WriteByte('"')
 	}
 
-	return result
+	return r.String()
 }
 
 var stringFlags = map[string]func(*string) cli.Flag{

--- a/cmd/fyne/internal/commands/flags_test.go
+++ b/cmd/fyne/internal/commands/flags_test.go
@@ -1,0 +1,16 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_keyValueFlag_String(t *testing.T) {
+	kvflag := &keyValueFlag{}
+	assert.NoError(t, kvflag.Set("foo=bar"))
+	assert.NoError(t, kvflag.Set("a=b=c"))
+	assert.Error(t, kvflag.Set("meep"))
+
+	assert.Equal(t, `"a=b=c", "foo=bar"`, kvflag.String())
+}

--- a/cmd/fyne/internal/commands/hardening_flags.go
+++ b/cmd/fyne/internal/commands/hardening_flags.go
@@ -6,7 +6,7 @@ import (
 
 	"golang.org/x/mod/semver"
 
-	intutil "fyne.io/tools/cmd/fyne/internal/util"
+	"fyne.io/tools/cmd/fyne/internal/util"
 )
 
 const (
@@ -42,7 +42,7 @@ func ccVersion() string {
 }
 
 func hardeningCFlagsLookup(out, goos, arch string) string {
-	info, err := intutil.DetectCompiler(out, goos)
+	info, err := util.DetectCompiler(out, goos)
 	if err != nil {
 		return ""
 	}

--- a/cmd/fyne/internal/commands/hardening_flags.go
+++ b/cmd/fyne/internal/commands/hardening_flags.go
@@ -21,9 +21,11 @@ type hardeningFlags struct {
 
 // specific flags go first, generic flags last
 var hardeningFlagsTable = []hardeningFlags{
+	//revive:disable:add-constant
 	{"ubuntu", "amd64", "gcc", "*", "11.4.0", "-fcf-protection -fstack-protector-strong"}, // Ubuntu 22.04/gcc 11.4.0 fails with _FORTIFY_SOURCE redefined error
 	{"windows", "*", "gcc", "*", "*", "-D_FORTIFY_SOURCE=3 -fstack-protector-strong"},     // mingw doesn't support -fcf-protection -- XXX: double check for better conditions
 	{"*", "arm64", "*", "*", "*", "-D_FORTIFY_SOURCE=3 -fstack-protector-strong"},         // -fcf-protection unsupported on arm64
+	//revive:enable:add-constant
 }
 
 func ccVersion() string {
@@ -47,6 +49,7 @@ func hardeningCFlagsLookup(out, goos, arch string) string {
 		return ""
 	}
 	for _, e := range hardeningFlagsTable {
+		//revive:disable:add-constant
 		if e.cc != "*" && e.cc != info.Name {
 			continue
 		}
@@ -63,6 +66,7 @@ func hardeningCFlagsLookup(out, goos, arch string) string {
 			continue
 		}
 		return e.cflags
+		//revive:enable:add-constant
 	}
 	return hardeningCFLAGS
 }

--- a/cmd/fyne/internal/commands/init.go
+++ b/cmd/fyne/internal/commands/init.go
@@ -12,6 +12,7 @@ import (
 
 	"fyne.io/tools/cmd/fyne/internal/metadata"
 	"fyne.io/tools/cmd/fyne/internal/templates"
+	"fyne.io/tools/cmd/fyne/internal/util"
 )
 
 func Init() *cli.Command {
@@ -152,7 +153,7 @@ func initAction(ctx *cli.Context) error {
 		return fmt.Errorf("failed to run command: %v", err)
 	}
 
-	if err := os.Mkdir("translations", 0o755); err != nil {
+	if err := os.Mkdir("translations", util.DirPermDefault); err != nil {
 		return err
 	}
 

--- a/cmd/fyne/internal/commands/install.go
+++ b/cmd/fyne/internal/commands/install.go
@@ -227,7 +227,7 @@ func (i *Installer) installRemote(ctx *cli.Context) error {
 
 	path := getInstallBaseDir(temp, pkg, repo.Root)
 
-	if !util.Exists(path) { // the error above may be ignorable, unless the path was not found
+	if !pkgUtil.Exists(path) { // the error above may be ignorable, unless the path was not found
 		return fmt.Errorf("path doesn't exist: %v", err)
 	}
 
@@ -253,7 +253,7 @@ func (i *Installer) install() error {
 	p := i.Packager
 
 	if i.os != "" {
-		if util.IsIOS(i.os) {
+		if pkgUtil.IsIOS(i.os) {
 			return i.installIOS()
 		} else if strings.Index(i.os, "android") == 0 {
 			return i.installAndroid()

--- a/cmd/fyne/internal/commands/package-darwin.go
+++ b/cmd/fyne/internal/commands/package-darwin.go
@@ -33,10 +33,10 @@ func darwinLangs(langs []string) []string {
 }
 
 func (p *Packager) packageDarwin() (err error) {
-	appDir := util.EnsureSubDir(p.dir, p.Name+".app")
+	appDir := pkgUtil.EnsureSubDir(p.dir, p.Name+".app")
 	exeName := filepath.Base(p.exe)
 
-	contentsDir := util.EnsureSubDir(appDir, "Contents")
+	contentsDir := pkgUtil.EnsureSubDir(appDir, "Contents")
 	info := filepath.Join(contentsDir, "Info.plist")
 	infoFile, err := os.Create(info)
 	if err != nil {
@@ -56,13 +56,13 @@ func (p *Packager) packageDarwin() (err error) {
 		return fmt.Errorf("failed to write plist template: %w", err)
 	}
 
-	macOSDir := util.EnsureSubDir(contentsDir, "MacOS")
+	macOSDir := pkgUtil.EnsureSubDir(contentsDir, "MacOS")
 	binName := filepath.Join(macOSDir, exeName)
-	if err := util.CopyExeFile(p.exe, binName); err != nil {
+	if err := pkgUtil.CopyExeFile(p.exe, binName); err != nil {
 		return fmt.Errorf("failed to copy executable: %w", err)
 	}
 
-	resDir := util.EnsureSubDir(contentsDir, "Resources")
+	resDir := pkgUtil.EnsureSubDir(contentsDir, "Resources")
 	icnsPath := filepath.Join(resDir, "icon.icns")
 
 	img, err := os.Open(p.icon)

--- a/cmd/fyne/internal/commands/package-mobile.go
+++ b/cmd/fyne/internal/commands/package-mobile.go
@@ -32,7 +32,7 @@ func (p *Packager) packageIOS(target string, tags []string) error {
 		return err
 	}
 
-	assetDir := util.EnsureSubDir(p.dir, "Images.xcassets")
+	assetDir := pkgUtil.EnsureSubDir(p.dir, "Images.xcassets")
 	defer os.RemoveAll(assetDir)
 	err = os.WriteFile(filepath.Join(assetDir, "Contents.json"), []byte(`{
   "info" : {
@@ -44,7 +44,7 @@ func (p *Packager) packageIOS(target string, tags []string) error {
 		fyne.LogError("Content err", err)
 	}
 
-	iconDir := util.EnsureSubDir(assetDir, "AppIcon.appiconset")
+	iconDir := pkgUtil.EnsureSubDir(assetDir, "AppIcon.appiconset")
 	contentFile, _ := os.Create(filepath.Join(iconDir, "Contents.json"))
 
 	err = templates.XCAssetsDarwin.Execute(contentFile, nil)

--- a/cmd/fyne/internal/commands/package-mobile.go
+++ b/cmd/fyne/internal/commands/package-mobile.go
@@ -52,20 +52,11 @@ func (p *Packager) packageIOS(target string, tags []string) error {
 		return fmt.Errorf("failed to write xcassets content template: %w", err)
 	}
 
-	if err = copyResizeIcon(1024, iconDir, p.icon); err != nil {
-		return err
-	}
-	if err = copyResizeIcon(180, iconDir, p.icon); err != nil {
-		return err
-	}
-	if err = copyResizeIcon(120, iconDir, p.icon); err != nil {
-		return err
-	}
-	if err = copyResizeIcon(76, iconDir, p.icon); err != nil {
-		return err
-	}
-	if err = copyResizeIcon(152, iconDir, p.icon); err != nil {
-		return err
+	iconSizes := []int{76, 120, 152, 180, 1024}
+	for _, iconSize := range iconSizes {
+		if err = copyResizeIcon(iconSize, iconDir, p.icon); err != nil {
+			return err
+		}
 	}
 
 	appDir := filepath.Join(p.dir, mobile.AppOutputName(p.os, p.Name, p.release))

--- a/cmd/fyne/internal/commands/package-mobile.go
+++ b/cmd/fyne/internal/commands/package-mobile.go
@@ -53,7 +53,7 @@ func (p *Packager) packageIOS(target string, tags []string) error {
 		return fmt.Errorf("failed to write xcassets content template: %w", err)
 	}
 
-	iconSizes := []int{76, 120, 152, 180, 1024}
+	iconSizes := []int{76, 120, 152, 180, 1024} //revive:disable-line:add-constant
 	for _, iconSize := range iconSizes {
 		if err = copyResizeIcon(iconSize, iconDir, p.icon); err != nil {
 			return err

--- a/cmd/fyne/internal/commands/package-mobile.go
+++ b/cmd/fyne/internal/commands/package-mobile.go
@@ -11,6 +11,7 @@ import (
 	"fyne.io/fyne/v2"
 	"fyne.io/tools/cmd/fyne/internal/mobile"
 	"fyne.io/tools/cmd/fyne/internal/templates"
+	"fyne.io/tools/cmd/fyne/internal/util"
 )
 
 func (p *Packager) packageAndroid(arch string, tags []string) error {
@@ -39,7 +40,7 @@ func (p *Packager) packageIOS(target string, tags []string) error {
     "author" : "xcode",
     "version" : 1
   }
-}`), 0o644)
+}`), util.FilePermDefault)
 	if err != nil {
 		fyne.LogError("Content err", err)
 	}

--- a/cmd/fyne/internal/commands/package-unix.go
+++ b/cmd/fyne/internal/commands/package-unix.go
@@ -36,21 +36,21 @@ func (p *Packager) packageUNIX() error {
 
 	outDir := p.dir
 	if !p.install {
-		outDir = util.EnsureSubDir(util.EnsureSubDir(p.dir, "tmp-pkg"), dirName)
+		outDir = pkgUtil.EnsureSubDir(pkgUtil.EnsureSubDir(p.dir, "tmp-pkg"), dirName)
 	}
 
 	if _, err := os.Stat(filepath.Join("/", "usr", "local")); os.IsNotExist(err) {
-		prefixDir = util.EnsureSubDir(outDir, "usr")
+		prefixDir = pkgUtil.EnsureSubDir(outDir, "usr")
 		local = ""
 	} else {
-		prefixDir = util.EnsureSubDir(util.EnsureSubDir(outDir, "usr"), "local")
+		prefixDir = pkgUtil.EnsureSubDir(pkgUtil.EnsureSubDir(outDir, "usr"), "local")
 	}
 
-	shareDir := util.EnsureSubDir(prefixDir, "share")
+	shareDir := pkgUtil.EnsureSubDir(prefixDir, "share")
 
-	binDir := util.EnsureSubDir(prefixDir, "bin")
+	binDir := pkgUtil.EnsureSubDir(prefixDir, "bin")
 	binName := filepath.Join(binDir, filepath.Base(p.exe))
-	err := util.CopyExeFile(p.exe, binName)
+	err := pkgUtil.CopyExeFile(p.exe, binName)
 	if err != nil {
 		return fmt.Errorf("failed to copy application binary file: %w", err)
 	}
@@ -60,10 +60,10 @@ func (p *Packager) packageUNIX() error {
 		appIDOrName = p.Name
 	}
 
-	iconDir := util.EnsureSubDir(shareDir, "pixmaps")
+	iconDir := pkgUtil.EnsureSubDir(shareDir, "pixmaps")
 	iconName := appIDOrName + filepath.Ext(p.icon)
 	iconPath := filepath.Join(iconDir, iconName)
-	err = util.CopyFile(p.icon, iconPath)
+	err = pkgUtil.CopyFile(p.icon, iconPath)
 	if err != nil {
 		return fmt.Errorf("failed to copy icon: %w", err)
 	}
@@ -75,7 +75,7 @@ func (p *Packager) packageUNIX() error {
 		openWith = " %F"
 	}
 
-	appsDir := util.EnsureSubDir(shareDir, "applications")
+	appsDir := pkgUtil.EnsureSubDir(shareDir, "applications")
 	desktop := filepath.Join(appsDir, appIDOrName+".desktop")
 	deskFile, err := os.Create(desktop)
 	if err != nil {

--- a/cmd/fyne/internal/commands/package-unix_test.go
+++ b/cmd/fyne/internal/commands/package-unix_test.go
@@ -11,6 +11,7 @@ import (
 
 	"fyne.io/fyne/v2/theme"
 	"fyne.io/tools/cmd/fyne/internal/templates"
+	"fyne.io/tools/cmd/fyne/internal/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli/v2"
 )
@@ -93,9 +94,9 @@ func TestPackageLinux(t *testing.T) {
 	basedir := t.TempDir()
 	dir := filepath.Join(basedir, "testapp")
 
-	assert.NoError(t, os.Mkdir(dir, 0o755), "create dir for test app")
+	assert.NoError(t, os.Mkdir(dir, util.DirPermDefault), "create dir for test app")
 	assert.NoError(t, os.Chdir(dir), "change into new app dir")
-	assert.NoError(t, os.WriteFile("Icon.png", theme.FyneLogo().Content(), 0o644)) //lint:ignore SA1019 It is fine for our own use.
+	assert.NoError(t, os.WriteFile("Icon.png", theme.FyneLogo().Content(), util.FilePermDefault)) //lint:ignore SA1019 It is fine for our own use.
 
 	app := &cli.App{
 		Name: "fyne",

--- a/cmd/fyne/internal/commands/package-util.go
+++ b/cmd/fyne/internal/commands/package-util.go
@@ -3,7 +3,7 @@ package commands
 import (
 	"os"
 
-	realUtil "fyne.io/tools/cmd/fyne/internal/util"
+	"fyne.io/tools/cmd/fyne/internal/util"
 )
 
 type packagerUtil interface {
@@ -26,15 +26,15 @@ type packagerUtil interface {
 type defaultUtil struct{}
 
 func (d defaultUtil) Exists(path string) bool {
-	return realUtil.Exists(path)
+	return util.Exists(path)
 }
 
 func (d defaultUtil) CopyFile(source string, target string) error {
-	return realUtil.CopyFile(source, target)
+	return util.CopyFile(source, target)
 }
 
 func (d defaultUtil) CopyExeFile(src, tgt string) error {
-	return realUtil.CopyExeFile(src, tgt)
+	return util.CopyExeFile(src, tgt)
 }
 
 func (d defaultUtil) WriteFile(target string, data []byte) error {
@@ -42,39 +42,39 @@ func (d defaultUtil) WriteFile(target string, data []byte) error {
 }
 
 func (d defaultUtil) EnsureSubDir(parent, name string) string {
-	return realUtil.EnsureSubDir(parent, name)
+	return util.EnsureSubDir(parent, name)
 }
 
 func (d defaultUtil) EnsureAbsPath(path string) string {
-	return realUtil.EnsureAbsPath(path)
+	return util.EnsureAbsPath(path)
 }
 
 func (d defaultUtil) MakePathRelativeTo(root, path string) string {
-	return realUtil.MakePathRelativeTo(root, path)
+	return util.MakePathRelativeTo(root, path)
 }
 
 func (d defaultUtil) RequireAndroidSDK() error {
-	return realUtil.RequireAndroidSDK()
+	return util.RequireAndroidSDK()
 }
 
 func (d defaultUtil) AndroidBuildToolsPath() string {
-	return realUtil.AndroidBuildToolsPath()
+	return util.AndroidBuildToolsPath()
 }
 
 func (d defaultUtil) IsAndroid(os string) bool {
-	return realUtil.IsAndroid(os)
+	return util.IsAndroid(os)
 }
 
 func (d defaultUtil) IsIOS(os string) bool {
-	return realUtil.IsIOS(os)
+	return util.IsIOS(os)
 }
 
 func (d defaultUtil) IsMobile(os string) bool {
-	return realUtil.IsMobile(os)
+	return util.IsMobile(os)
 }
 
-var util packagerUtil
+var pkgUtil packagerUtil
 
 func init() {
-	util = defaultUtil{}
+	pkgUtil = defaultUtil{}
 }

--- a/cmd/fyne/internal/commands/package-util.go
+++ b/cmd/fyne/internal/commands/package-util.go
@@ -38,7 +38,7 @@ func (d defaultUtil) CopyExeFile(src, tgt string) error {
 }
 
 func (d defaultUtil) WriteFile(target string, data []byte) error {
-	return os.WriteFile(target, data, 0o644)
+	return os.WriteFile(target, data, util.FilePermDefault)
 }
 
 func (d defaultUtil) EnsureSubDir(parent, name string) string {

--- a/cmd/fyne/internal/commands/package-wasm.go
+++ b/cmd/fyne/internal/commands/package-wasm.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (p *Packager) packageWasm() error {
-	appDir := util.EnsureSubDir(p.dir, "wasm")
+	appDir := pkgUtil.EnsureSubDir(p.dir, "wasm")
 
 	tpl := webData{
 		AppName:    p.Name,
@@ -37,37 +37,37 @@ func (w webData) packageWebInternal(appDir string, exeWasmSrc string, icon strin
 	}
 
 	index := filepath.Join(appDir, "index.html")
-	err = util.WriteFile(index, tpl.Bytes())
+	err = pkgUtil.WriteFile(index, tpl.Bytes())
 	if err != nil {
 		return err
 	}
 
 	iconDst := filepath.Join(appDir, "icon.png")
-	err = util.CopyFile(icon, iconDst)
+	err = pkgUtil.CopyFile(icon, iconDst)
 	if err != nil {
 		return err
 	}
 
 	spinnerLightFile := filepath.Join(appDir, "spinner_light.gif")
-	err = util.WriteFile(spinnerLightFile, templates.SpinnerLight)
+	err = pkgUtil.WriteFile(spinnerLightFile, templates.SpinnerLight)
 	if err != nil {
 		return err
 	}
 
 	spinnerDarkFile := filepath.Join(appDir, "spinner_dark.gif")
-	err = util.WriteFile(spinnerDarkFile, templates.SpinnerDark)
+	err = pkgUtil.WriteFile(spinnerDarkFile, templates.SpinnerDark)
 	if err != nil {
 		return err
 	}
 
 	lightCSSFile := filepath.Join(appDir, "light.css")
-	err = util.WriteFile(lightCSSFile, templates.CSSLight)
+	err = pkgUtil.WriteFile(lightCSSFile, templates.CSSLight)
 	if err != nil {
 		return err
 	}
 
 	darkCSSFile := filepath.Join(appDir, "dark.css")
-	err = util.WriteFile(darkCSSFile, templates.CSSDark)
+	err = pkgUtil.WriteFile(darkCSSFile, templates.CSSDark)
 	if err != nil {
 		return err
 	}
@@ -78,18 +78,18 @@ func (w webData) packageWebInternal(appDir string, exeWasmSrc string, icon strin
 	}
 
 	wasmExecSrc := filepath.Join(goroot, "lib", "wasm", "wasm_exec.js")
-	if !util.Exists(wasmExecSrc) { // Fallback for Go < 1.24:
+	if !pkgUtil.Exists(wasmExecSrc) { // Fallback for Go < 1.24:
 		wasmExecSrc = filepath.Join(goroot, "misc", "wasm", "wasm_exec.js")
 	}
 
 	wasmExecDst := filepath.Join(appDir, "wasm_exec.js")
-	err = util.CopyFile(wasmExecSrc, wasmExecDst)
+	err = pkgUtil.CopyFile(wasmExecSrc, wasmExecDst)
 	if err != nil {
 		return err
 	}
 
 	exeWasmDst := filepath.Join(appDir, w.WasmFile)
-	err = util.CopyFile(exeWasmSrc, exeWasmDst)
+	err = pkgUtil.CopyFile(exeWasmSrc, exeWasmDst)
 	if err != nil {
 		return err
 	}
@@ -97,7 +97,7 @@ func (w webData) packageWebInternal(appDir string, exeWasmSrc string, icon strin
 	// Download webgl-debug.js directly from the KhronosGroup repository when needed
 	if !release {
 		webglDebugFile := filepath.Join(appDir, "webgl-debug.js")
-		err := util.WriteFile(webglDebugFile, templates.WebGLDebugJs)
+		err := pkgUtil.WriteFile(webglDebugFile, templates.WebGLDebugJs)
 		if err != nil {
 			return err
 		}

--- a/cmd/fyne/internal/commands/package.go
+++ b/cmd/fyne/internal/commands/package.go
@@ -191,13 +191,13 @@ func (p *Packager) doPackage(runner runner) error {
 		tags = strings.Split(p.tags, ",")
 	}
 
-	if !util.Exists(p.exe) && !util.IsMobile(p.os) {
+	if !pkgUtil.Exists(p.exe) && !pkgUtil.IsMobile(p.os) {
 		files, err := p.buildPackage(runner, tags)
 		if err != nil {
 			return fmt.Errorf("error building application: %w", err)
 		}
 		for _, file := range files {
-			if p.os != "web" && !util.Exists(file) {
+			if p.os != "web" && !pkgUtil.Exists(file) {
 				return fmt.Errorf("unable to build directory to expected executable, %s", file)
 			}
 		}
@@ -205,7 +205,7 @@ func (p *Packager) doPackage(runner runner) error {
 			defer p.removeBuild(files)
 		}
 	}
-	if util.IsMobile(p.os) { // we don't use the normal build command for mobile so inject before gomobile...
+	if pkgUtil.IsMobile(p.os) { // we don't use the normal build command for mobile so inject before gomobile...
 		close, err := injectMetadataIfPossible(p.dir, p.appData, createMetadataInitFile)
 		if err != nil {
 			fyne.LogError("Failed to inject metadata init file, omitting metadata", err)
@@ -266,7 +266,7 @@ func (p *Packager) validate() (err error) {
 			return errors.New("parameter --source-dir is currently not supported for mobile builds. " +
 				"Change directory to the main package and try again")
 		}
-		p.srcDir = util.EnsureAbsPath(p.srcDir)
+		p.srcDir = pkgUtil.EnsureAbsPath(p.srcDir)
 	}
 	if err := os.Chdir(p.srcDir); err != nil {
 		return err
@@ -282,7 +282,7 @@ func (p *Packager) validate() (err error) {
 	if err == nil {
 		// When icon path specified in metadata file, we should make it relative to metadata file
 		if data.Details.Icon != "" {
-			data.Details.Icon = util.MakePathRelativeTo(p.srcDir, data.Details.Icon)
+			data.Details.Icon = pkgUtil.MakePathRelativeTo(p.srcDir, data.Details.Icon)
 		}
 
 		p.mergeMetadata(data)
@@ -297,7 +297,7 @@ func (p *Packager) validate() (err error) {
 	if p.exe == "" {
 		p.exe = filepath.Join(p.srcDir, exeName)
 
-		if util.Exists(p.exe) { // the exe was not specified, assume stale
+		if pkgUtil.Exists(p.exe) { // the exe was not specified, assume stale
 			p.removeBuild([]string{p.exe})
 		}
 	} else if p.os == "ios" || p.os == "android" {
@@ -310,7 +310,7 @@ func (p *Packager) validate() (err error) {
 	if p.icon == "" || p.icon == "Icon.png" {
 		p.icon = filepath.Join(p.srcDir, "Icon.png")
 	}
-	if !util.Exists(p.icon) {
+	if !pkgUtil.Exists(p.icon) {
 		return errors.New("Missing application icon at \"" + p.icon + "\"")
 	}
 	if strings.ToLower(filepath.Ext(p.icon)) != ".png" {
@@ -403,13 +403,13 @@ func validateAppID(appID, os, name string, release bool) (string, error) {
 		if appID == "" {
 			return "com.example." + name, nil
 		}
-	} else if os == "ios" || util.IsAndroid(os) || (os == "windows" && release) {
+	} else if os == "ios" || pkgUtil.IsAndroid(os) || (os == "windows" && release) {
 		// all mobile, and for windows when releasing, needs a unique id - usually reverse DNS style
 		if appID == "" {
 			return "", errors.New("missing app-id parameter for package")
 		} else if !strings.Contains(appID, ".") {
 			return "", errors.New("app-id must be globally unique and contain at least 1 '.'")
-		} else if util.IsAndroid(os) {
+		} else if pkgUtil.IsAndroid(os) {
 			if strings.Contains(appID, "-") {
 				return "", errors.New("app-id can not contain '-'")
 			}

--- a/cmd/fyne/internal/commands/package.go
+++ b/cmd/fyne/internal/commands/package.go
@@ -399,33 +399,33 @@ func (p *Packager) normaliseIcon(path string) (string, error) {
 
 func validateAppID(appID, os, name string, release bool) (string, error) {
 	// old darwin compatibility
-	if os == "darwin" {
-		if appID == "" {
-			return "com.example." + name, nil
+	if os == "darwin" && appID == "" {
+		return "com.example." + name, nil
+	} else if os != "ios" && !pkgUtil.IsAndroid(os) && !(os == "windows" && release) {
+		return appID, nil
+	}
+
+	// all mobile, and for windows when releasing, needs a unique id - usually reverse DNS style
+	if appID == "" {
+		return "", errors.New("missing app-id parameter for package")
+	} else if !strings.Contains(appID, ".") {
+		return "", errors.New("app-id must be globally unique and contain at least 1 '.'")
+	} else if pkgUtil.IsAndroid(os) {
+		if strings.Contains(appID, "-") {
+			return "", errors.New("app-id can not contain '-'")
 		}
-	} else if os == "ios" || pkgUtil.IsAndroid(os) || (os == "windows" && release) {
-		// all mobile, and for windows when releasing, needs a unique id - usually reverse DNS style
-		if appID == "" {
-			return "", errors.New("missing app-id parameter for package")
-		} else if !strings.Contains(appID, ".") {
-			return "", errors.New("app-id must be globally unique and contain at least 1 '.'")
-		} else if pkgUtil.IsAndroid(os) {
-			if strings.Contains(appID, "-") {
-				return "", errors.New("app-id can not contain '-'")
+
+		// appID package names can not start with '_' or a number
+		packageNames := strings.Split(appID, ".")
+		for _, name := range packageNames {
+			if len(name) == 0 {
+				continue
 			}
 
-			// appID package names can not start with '_' or a number
-			packageNames := strings.Split(appID, ".")
-			for _, name := range packageNames {
-				if len(name) == 0 {
-					continue
-				}
-
-				if name[0] == '_' {
-					return "", fmt.Errorf("app-id package names can not start with '_' (%s)", name)
-				} else if name[0] >= '0' && name[0] <= '9' {
-					return "", fmt.Errorf("app-id package names can not start with a number (%s)", name)
-				}
+			if name[0] == '_' {
+				return "", fmt.Errorf("app-id package names can not start with '_' (%s)", name)
+			} else if name[0] >= '0' && name[0] <= '9' {
+				return "", fmt.Errorf("app-id package names can not start with a number (%s)", name)
 			}
 		}
 	}

--- a/cmd/fyne/internal/commands/package_test.go
+++ b/cmd/fyne/internal/commands/package_test.go
@@ -251,7 +251,7 @@ func Test_PackageWasm(t *testing.T) {
 	}
 	wasmBuildTest := &testCommandRuns{runs: expected, t: t}
 
-	util = mockUtil{}
+	pkgUtil = mockUtil{}
 
 	utilIsMobileMock = func(_ string) bool {
 		return false

--- a/cmd/fyne/internal/commands/release.go
+++ b/cmd/fyne/internal/commands/release.go
@@ -145,11 +145,7 @@ func (r *Releaser) releaseAction(_ *cli.Context) error {
 		return err
 	}
 
-	if err := r.afterPackage(); err != nil {
-		return err
-	}
-
-	return nil
+	return r.afterPackage()
 }
 
 func (r *Releaser) afterPackage() error {

--- a/cmd/fyne/internal/commands/release.go
+++ b/cmd/fyne/internal/commands/release.go
@@ -152,7 +152,7 @@ func (r *Releaser) releaseAction(_ *cli.Context) error {
 }
 
 func (r *Releaser) afterPackage() error {
-	if util.IsAndroid(r.os) {
+	if pkgUtil.IsAndroid(r.os) {
 		target := mobile.AppOutputName(r.os, r.Name, r.release)
 		apk := filepath.Join(r.dir, target)
 		if err := r.zipAlign(apk); err != nil {
@@ -183,8 +183,8 @@ func (r *Releaser) afterPackage() error {
 }
 
 func (r *Releaser) beforePackage() error {
-	if util.IsAndroid(r.os) {
-		if err := util.RequireAndroidSDK(); err != nil {
+	if pkgUtil.IsAndroid(r.os) {
+		if err := pkgUtil.RequireAndroidSDK(); err != nil {
 			return err
 		}
 	}
@@ -296,8 +296,8 @@ func (r *Releaser) packageWindowsRelease(outFile string) error {
 		return errors.New("failed to write application manifest template")
 	}
 
-	util.CopyFile(r.icon, filepath.Join(payload, "Icon.png"))
-	util.CopyFile(r.Name, filepath.Join(payload, r.Name))
+	pkgUtil.CopyFile(r.icon, filepath.Join(payload, "Icon.png"))
+	pkgUtil.CopyFile(r.Name, filepath.Join(payload, r.Name))
 
 	binDir, err := findWindowsSDKBin()
 	if err != nil {
@@ -317,7 +317,7 @@ func (r *Releaser) signAndroid(path string) error {
 	if r.release {
 		args = []string{"-keystore", r.keyStore}
 	} else {
-		signer = filepath.Join(util.AndroidBuildToolsPath(), "/apksigner")
+		signer = filepath.Join(pkgUtil.AndroidBuildToolsPath(), "/apksigner")
 		args = []string{"sign", "--ks", r.keyStore}
 	}
 
@@ -373,7 +373,7 @@ func (r *Releaser) validate() error {
 		return err
 	}
 
-	if util.IsMobile(r.os) || r.os == "windows" {
+	if pkgUtil.IsMobile(r.os) || r.os == "windows" {
 		if r.AppVersion == "" { // Here it is required, if provided then package validate will check format
 			return errors.New("missing required --app-version parameter")
 		}
@@ -393,7 +393,7 @@ func (r *Releaser) validate() error {
 			return errors.New("missing required --password parameter for windows release")
 		}
 	}
-	if util.IsAndroid(r.os) {
+	if pkgUtil.IsAndroid(r.os) {
 		if r.keyStore == "" {
 			return errors.New("missing required --keystore parameter for android release")
 		}
@@ -448,7 +448,7 @@ func (r *Releaser) zipAlign(path string) error {
 		return nil
 	}
 
-	cmd := filepath.Join(util.AndroidBuildToolsPath(), "zipalign")
+	cmd := filepath.Join(pkgUtil.AndroidBuildToolsPath(), "zipalign")
 	err = exec.Command(cmd, "16", unaligned, path).Run()
 	if err != nil {
 		_ = os.Rename(path, unaligned) // ignore error, return previous

--- a/cmd/fyne/internal/commands/release.go
+++ b/cmd/fyne/internal/commands/release.go
@@ -13,6 +13,7 @@ import (
 	"fyne.io/fyne/v2"
 	"fyne.io/tools/cmd/fyne/internal/mobile"
 	"fyne.io/tools/cmd/fyne/internal/templates"
+	"fyne.io/tools/cmd/fyne/internal/util"
 
 	"github.com/urfave/cli/v2"
 )
@@ -211,7 +212,7 @@ func (r *Releaser) packageIOSRelease() error {
 	}
 
 	payload := filepath.Join(r.dir, "Payload")
-	_ = os.Mkdir(payload, 0o750)
+	_ = os.Mkdir(payload, util.PermUserReadWriteExec|util.PermGroupRead|util.PermGroupExec)
 	defer os.RemoveAll(payload)
 	appName := mobile.AppOutputName(r.os, r.Name, r.release)
 	payloadAppDir := filepath.Join(payload, appName)
@@ -274,7 +275,7 @@ func (r *Releaser) packageMacOSRelease() error {
 
 func (r *Releaser) packageWindowsRelease(outFile string) error {
 	payload := filepath.Join(r.dir, "Payload")
-	_ = os.Mkdir(payload, 0o750)
+	_ = os.Mkdir(payload, util.PermUserReadWriteExec|util.PermGroupRead|util.PermGroupExec)
 	defer os.RemoveAll(payload)
 
 	manifestPath := filepath.Join(payload, "appxmanifest.xml")

--- a/cmd/fyne/internal/commands/serve.go
+++ b/cmd/fyne/internal/commands/serve.go
@@ -69,7 +69,7 @@ func (s *Server) serve() error {
 		return err
 	}
 
-	webDir := util.EnsureSubDir(s.dir, "wasm")
+	webDir := pkgUtil.EnsureSubDir(s.dir, "wasm")
 	fileServer := http.FileServer(http.Dir(webDir))
 
 	http.Handle("/", fileServer)

--- a/cmd/fyne/internal/commands/serve.go
+++ b/cmd/fyne/internal/commands/serve.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	"strconv"
 
@@ -88,11 +89,13 @@ func (s *Server) Server(ctx *cli.Context) error {
 	return s.serve()
 }
 
+const defaultServerPort = 8080
+
 func (s *Server) validate() error {
 	if s.port == 0 {
-		s.port = 8080
+		s.port = defaultServerPort
 	}
-	if s.port < 0 || s.port > 65535 {
+	if s.port < 0 || s.port > math.MaxUint16 {
 		return fmt.Errorf("the port must be a strictly positive number and be strictly smaller than 65536 (Got %v)", s.port)
 	}
 	return nil

--- a/cmd/fyne/internal/mobile/android_resources.go
+++ b/cmd/fyne/internal/mobile/android_resources.go
@@ -34,7 +34,7 @@ func generateAdaptiveIconXML(hasMonochrome bool) string {
 // writeAdaptiveIconResources creates all necessary resource files for adaptive icons
 func writeAdaptiveIconResources(resDir, foregroundPath, backgroundPath, monochromePath string) error {
 	xxxhdpiDir := filepath.Join(resDir, "mipmap-xxxhdpi")
-	if err := os.MkdirAll(xxxhdpiDir, 0o755); err != nil {
+	if err := os.MkdirAll(xxxhdpiDir, util.DirPermDefault); err != nil {
 		return fmt.Errorf("failed to create mipmap-xxxhdpi directory: %w", err)
 	}
 
@@ -57,16 +57,16 @@ func writeAdaptiveIconResources(resDir, foregroundPath, backgroundPath, monochro
 
 	// Create mipmap-anydpi-v26 metadata for adaptive icon XML
 	anydpiV26Dir := filepath.Join(resDir, "mipmap-anydpi-v26")
-	if err := os.MkdirAll(anydpiV26Dir, 0o755); err != nil {
+	if err := os.MkdirAll(anydpiV26Dir, util.DirPermDefault); err != nil {
 		return fmt.Errorf("failed to create mipmap-anydpi-v26 directory: %w", err)
 	}
 
 	adaptiveXML := generateAdaptiveIconXML(false) // v26 doesn't include monochrome
-	if err := os.WriteFile(filepath.Join(anydpiV26Dir, "ic_launcher.xml"), []byte(adaptiveXML), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(anydpiV26Dir, "ic_launcher.xml"), []byte(adaptiveXML), util.FilePermDefault); err != nil {
 		return fmt.Errorf("failed to write ic_launcher.xml: %w", err)
 	}
 
-	if err := os.WriteFile(filepath.Join(anydpiV26Dir, "ic_launcher_round.xml"), []byte(adaptiveXML), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(anydpiV26Dir, "ic_launcher_round.xml"), []byte(adaptiveXML), util.FilePermDefault); err != nil {
 		return fmt.Errorf("failed to write ic_launcher_round.xml: %w", err)
 	}
 
@@ -75,16 +75,16 @@ func writeAdaptiveIconResources(resDir, foregroundPath, backgroundPath, monochro
 	}
 	// If monochrome provided, create v33 resources with monochrome support
 	anydpiV33Dir := filepath.Join(resDir, "mipmap-anydpi-v33")
-	if err := os.MkdirAll(anydpiV33Dir, 0o755); err != nil {
+	if err := os.MkdirAll(anydpiV33Dir, util.DirPermDefault); err != nil {
 		return fmt.Errorf("failed to create mipmap-anydpi-v33 directory: %w", err)
 	}
 
 	adaptiveXMLWithMono := generateAdaptiveIconXML(true)
-	if err := os.WriteFile(filepath.Join(anydpiV33Dir, "ic_launcher.xml"), []byte(adaptiveXMLWithMono), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(anydpiV33Dir, "ic_launcher.xml"), []byte(adaptiveXMLWithMono), util.FilePermDefault); err != nil {
 		return fmt.Errorf("failed to write v33 ic_launcher.xml: %w", err)
 	}
 
-	if err := os.WriteFile(filepath.Join(anydpiV33Dir, "ic_launcher_round.xml"), []byte(adaptiveXMLWithMono), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(anydpiV33Dir, "ic_launcher_round.xml"), []byte(adaptiveXMLWithMono), util.FilePermDefault); err != nil {
 		return fmt.Errorf("failed to write v33 ic_launcher_round.xml: %w", err)
 	}
 	return nil
@@ -99,7 +99,7 @@ func compileAndroidResources(tempDir string, manifestData []byte, foregroundPath
 	}
 
 	resDir = filepath.Join(tempDir, "res")
-	if err := os.MkdirAll(resDir, 0o755); err != nil {
+	if err := os.MkdirAll(resDir, util.DirPermDefault); err != nil {
 		return "", "", "", fmt.Errorf("failed to create res directory: %w", err)
 	}
 
@@ -108,12 +108,12 @@ func compileAndroidResources(tempDir string, manifestData []byte, foregroundPath
 	}
 
 	compiledDir := filepath.Join(tempDir, "compiled")
-	if err := os.MkdirAll(compiledDir, 0o755); err != nil {
+	if err := os.MkdirAll(compiledDir, util.DirPermDefault); err != nil {
 		return "", "", "", fmt.Errorf("failed to create compiled directory: %w", err)
 	}
 
 	tempManifestPath := filepath.Join(tempDir, "AndroidManifest.xml")
-	if err := os.WriteFile(tempManifestPath, manifestData, 0o644); err != nil {
+	if err := os.WriteFile(tempManifestPath, manifestData, util.FilePermDefault); err != nil {
 		return "", "", "", fmt.Errorf("failed to write AndroidManifest.xml: %w", err)
 	}
 
@@ -239,7 +239,7 @@ func extractDirFromZip(zipPath, prefix, destDir string) error {
 	}
 	defer r.Close()
 
-	if err := os.MkdirAll(destDir, 0o755); err != nil {
+	if err := os.MkdirAll(destDir, util.DirPermDefault); err != nil {
 		return err
 	}
 
@@ -255,12 +255,12 @@ func extractDirFromZip(zipPath, prefix, destDir string) error {
 		destPath := filepath.Join(destDir, relPath)
 
 		if f.FileInfo().IsDir() {
-			if err := os.MkdirAll(destPath, 0o755); err != nil {
+			if err := os.MkdirAll(destPath, util.DirPermDefault); err != nil {
 				return err
 			}
 			continue
 		}
-		if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(destPath), util.DirPermDefault); err != nil {
 			return err
 		}
 

--- a/cmd/fyne/internal/mobile/android_resources.go
+++ b/cmd/fyne/internal/mobile/android_resources.go
@@ -194,6 +194,23 @@ func compileAndroidResources(tempDir string, manifestData []byte, foregroundPath
 	return arscPath, extractedResDir, manifestPath, nil
 }
 
+func copyZipFileToPath(f *zip.File, destPath string) error {
+	rc, err := f.Open()
+	if err != nil {
+		return err
+	}
+	defer rc.Close()
+
+	dest, err := os.Create(destPath)
+	if err != nil {
+		return err
+	}
+	defer dest.Close()
+
+	_, err = io.Copy(dest, rc)
+	return err
+}
+
 // extractFileFromZip extracts a single file from a zip archive
 func extractFileFromZip(zipPath, fileName, destPath string) error {
 	r, err := zip.OpenReader(zipPath)
@@ -207,20 +224,9 @@ func extractFileFromZip(zipPath, fileName, destPath string) error {
 			continue
 		}
 
-		rc, err := f.Open()
-		if err != nil {
+		if err := copyZipFileToPath(f, destPath); err != nil {
 			return err
 		}
-		defer rc.Close()
-
-		dest, err := os.Create(destPath)
-		if err != nil {
-			return err
-		}
-		defer dest.Close()
-
-		_, err = io.Copy(dest, rc)
-		return err
 	}
 	return fmt.Errorf("file %s not found in zip", fileName)
 }
@@ -259,21 +265,7 @@ func extractDirFromZip(zipPath, prefix, destDir string) error {
 		}
 
 		// Extract file
-		rc, err := f.Open()
-		if err != nil {
-			return err
-		}
-
-		dest, err := os.Create(destPath)
-		if err != nil {
-			rc.Close()
-			return err
-		}
-
-		_, err = io.Copy(dest, rc)
-		rc.Close()
-		dest.Close()
-		if err != nil {
+		if err := copyZipFileToPath(f, destPath); err != nil {
 			return err
 		}
 	}

--- a/cmd/fyne/internal/mobile/binres/binres_string.go
+++ b/cmd/fyne/internal/mobile/binres/binres_string.go
@@ -53,6 +53,7 @@ func (i ResType) String() string {
 		return "ResType(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
 }
+
 func _() {
 	// An "invalid array index" compiler error signifies that the constant values have changed.
 	// Re-run the stringer command to generate them again.

--- a/cmd/fyne/internal/mobile/binres/genarsc.go
+++ b/cmd/fyne/internal/mobile/binres/genarsc.go
@@ -37,7 +37,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	if err := os.WriteFile("arsc.go", []byte(fmt.Sprintf(tmpl, strconv.Quote(string(arsc)))), 0o644); err != nil {
+	if err := os.WriteFile("arsc.go", []byte(fmt.Sprintf(tmpl, strconv.Quote(string(arsc)))), util.FilePermDefault); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/cmd/fyne/internal/mobile/binres/genarsc.go
+++ b/cmd/fyne/internal/mobile/binres/genarsc.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 
 	"fyne.io/tools/cmd/fyne/internal/mobile/binres"
+	"fyne.io/tools/cmd/fyne/internal/util"
 )
 
 const tmpl = `// Copyright 2016 The Go Authors.  All rights reserved.

--- a/cmd/fyne/internal/mobile/build_androidapp.go
+++ b/cmd/fyne/internal/mobile/build_androidapp.go
@@ -479,7 +479,7 @@ func convertAPKToAAB(aabPath string) error {
 	apkPath := buildO[:len(aabPath)-3] + "apk"
 	apkProtoPath := buildO[:len(aabPath)-3] + "apk-proto"
 	tmpPath := filepath.Join(filepath.Dir(aabPath), "tmpbundle")
-	err := os.MkdirAll(tmpPath, 0o755)
+	err := os.MkdirAll(tmpPath, util.DirPermDefault)
 	if err != nil {
 		return err
 	}
@@ -507,8 +507,8 @@ func convertAPKToAAB(aabPath string) error {
 	}
 	_ = os.Remove(apkProtoPath)
 
-	_ = os.MkdirAll(filepath.Join(tmpPath, "dex"), 0o755)
-	_ = os.MkdirAll(filepath.Join(tmpPath, "manifest"), 0o755)
+	_ = os.MkdirAll(filepath.Join(tmpPath, "dex"), util.DirPermDefault)
+	_ = os.MkdirAll(filepath.Join(tmpPath, "manifest"), util.DirPermDefault)
 	_ = os.Rename(filepath.Join(tmpPath, "AndroidManifest.xml"), filepath.Join(tmpPath, "manifest", "AndroidManifest.xml"))
 	_ = os.Rename(filepath.Join(tmpPath, "classes.dex"), filepath.Join(tmpPath, "dex", "classes.dex"))
 

--- a/cmd/fyne/internal/mobile/build_iosapp.go
+++ b/cmd/fyne/internal/mobile/build_iosapp.go
@@ -19,6 +19,8 @@ import (
 	"text/template"
 
 	"golang.org/x/tools/go/packages"
+
+	"fyne.io/tools/cmd/fyne/internal/util"
 )
 
 func goIOSBuild(pkg *packages.Package, bundleID string, archs []string,
@@ -78,7 +80,7 @@ func goIOSBuild(pkg *packages.Package, bundleID string, archs []string,
 			printcmd("echo \"%s\" > %s", file.contents, file.name)
 		}
 		if !buildN {
-			if err := os.WriteFile(file.name, file.contents, 0o600); err != nil {
+			if err := os.WriteFile(file.name, file.contents, util.PermUserRead|util.PermUserWrite); err != nil {
 				return nil, err
 			}
 		}

--- a/cmd/fyne/internal/mobile/gendex/gendex.go
+++ b/cmd/fyne/internal/mobile/gendex/gendex.go
@@ -27,6 +27,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sort"
+
+	"fyne.io/tools/cmd/fyne/internal/util"
 )
 
 var outfile = flag.String("o", "dex.go", "result will be written file")
@@ -54,7 +56,7 @@ func gendex() error {
 	if androidHome == "" {
 		return errors.New("ANDROID_HOME not set")
 	}
-	if err := os.MkdirAll(tmpdir+"/work/org/golang/app", 0o775); err != nil {
+	if err := os.MkdirAll(tmpdir+"/work/org/golang/app", util.DirPermDefault|util.PermGroupWrite); err != nil {
 		return err
 	}
 	javaFiles, err := filepath.Glob("../../../../../fyne/internal/driver/mobile/app/*.java")
@@ -227,7 +229,7 @@ func stripMethodParameters(path string) error {
 		return err
 	}
 
-	return os.WriteFile(path, out.Bytes(), 0o644)
+	return os.WriteFile(path, out.Bytes(), util.FilePermDefault)
 }
 
 func rewriteAttributes(r *classReader, out *bytes.Buffer, dropName uint16) error {

--- a/cmd/fyne/internal/mobile/init.go
+++ b/cmd/fyne/internal/mobile/init.go
@@ -11,6 +11,8 @@ import (
 	"os/exec"
 	"runtime"
 	"strings"
+
+	"fyne.io/tools/cmd/fyne/internal/util"
 )
 
 func mkdir(dir string) error {
@@ -20,7 +22,7 @@ func mkdir(dir string) error {
 	if buildN {
 		return nil
 	}
-	return os.MkdirAll(dir, 0o750)
+	return os.MkdirAll(dir, util.PermUserReadWriteExec|util.PermGroupRead|util.PermGroupExec)
 }
 
 func removeAll(path string) error {

--- a/cmd/fyne/internal/util/file.go
+++ b/cmd/fyne/internal/util/file.go
@@ -8,6 +8,25 @@ import (
 	"fyne.io/fyne/v2"
 )
 
+// Constants for file permissions to be combined using `|`.
+const (
+	PermGroupExec         = 0o10
+	PermGroupRead         = 0o40
+	PermGroupWrite        = 0o20
+	PermOtherExec         = 0o1
+	PermOtherRead         = 0o4
+	PermOtherWrite        = 0o2
+	PermUserExec          = 0o100
+	PermUserRead          = 0o400
+	PermUserReadWriteExec = PermUserExec | PermUserRead | PermUserWrite
+	PermUserWrite         = 0o200
+)
+
+const (
+	DirPermDefault  = PermGroupExec | PermGroupRead | PermOtherExec | PermOtherRead | PermUserReadWriteExec
+	FilePermDefault = PermGroupRead | PermGroupWrite | PermOtherRead | PermOtherWrite | PermUserRead | PermUserWrite
+)
+
 // Exists will return true if the passed path exists on the current system.
 func Exists(path string) bool {
 	_, err := os.Stat(path)
@@ -19,12 +38,12 @@ func Exists(path string) bool {
 
 // CopyFile copies the content of a regular file, source, into target path.
 func CopyFile(source, target string) error {
-	return copyFileMode(source, target, 0o644)
+	return copyFileMode(source, target, FilePermDefault)
 }
 
 // CopyExeFile copies the content of an executable file, source, into target path.
 func CopyExeFile(src, tgt string) error {
-	return copyFileMode(src, tgt, 0o755)
+	return copyFileMode(src, tgt, DirPermDefault)
 }
 
 // EnsureSubDir will make sure a named directory exists within the parent - creating it if not.


### PR DESCRIPTION
This one comes with a few cleanups:
 - Rename global `util` variable to `pkgUtil` to reduce confusion and import conflicts
 - Move file permissions to `util` package
 - Disable constant checks in a few selected code blocks
 - Refactoring small functions/simple code-paths

Other than that, the commit message should be pretty accurate.